### PR TITLE
Add support for converting the Wiff datatype to the msconvert tool.

### DIFF
--- a/tools/msconvert/msconvert.xml
+++ b/tools/msconvert/msconvert.xml
@@ -8,11 +8,24 @@
   </requirements>
 -->
   <command interpreter="python">
+    #import re
     #set $ext = $input.ext
     msconvert_wrapper.py
-    --input=${input}
-    #if hasattr($input, 'display_name')
-    --input_name='${input.display_name}'
+    #if $type.input_type == 'wiff':
+      #set basename = 'absciex'
+      #if hasattr($input, 'display_name')
+        #set basename = $re.sub('\W','_',$input.display_name)
+      #end if
+      --input=${input.extra_files_path}/wiff
+      --input_name='${basename}.wiff
+      --implicit=${input.extra_files_path}/wiff_scan
+      --input=${input.extra_files_path}/wiff_scan
+      --input_name='${basename}.wiff.scan
+    #else
+      --input=${input}
+      #if hasattr($input, 'display_name')
+      --input_name='${input.display_name}'
+      #end if
     #end if
     --output=${output}
     ## BEGIN_VERSION_DEFAULT
@@ -122,6 +135,7 @@
         <option value="mzxml">mzXML</option>
         <option value="mgf">mgf</option>
         <option value="ms2">ms2</option>
+        <option value="wiff">wiff</option>
       </param>
       <when value="mzml">
         <param format="mzml" name="input" type="data" label="Input mzML"/>
@@ -134,6 +148,9 @@
       </when>
       <when value="ms2">
         <param format="ms2" name="input" type="data" label="Input ms2"/>
+      </when>
+      <when value="wiff">
+        <param format="wiff" name="input" type="data" label="Input wiff"/>
       </when>
     </conditional>
     <!-- END_VERSION_DEFAULT -->
@@ -371,7 +388,7 @@ You can view the original documentation here_.
 
 For the underlying tool, please cite `ProteoWizard: Open Source Software for Rapid Proteomics Tools Development. Darren Kessner; Matt Chambers; Robert Burke; David Agus; Parag Mallick. Bioinformatics 2008; doi: 10.1093/bioinformatics/btn323.`
 
-If you use this tool in Galaxy, please cite Chilton J, et al. https://github.com/galaxyproteomics/
+If you use this tool in Galaxy, please cite Chilton J, et al. https://bitbucket.org/galaxyp/msconvert
 
   </help>
 </tool>

--- a/tools/msconvert/msconvert.xml
+++ b/tools/msconvert/msconvert.xml
@@ -388,7 +388,7 @@ You can view the original documentation here_.
 
 For the underlying tool, please cite `ProteoWizard: Open Source Software for Rapid Proteomics Tools Development. Darren Kessner; Matt Chambers; Robert Burke; David Agus; Parag Mallick. Bioinformatics 2008; doi: 10.1093/bioinformatics/btn323.`
 
-If you use this tool in Galaxy, please cite Chilton J, et al. https://bitbucket.org/galaxyp/msconvert
+If you use this tool in Galaxy, please cite Chilton J, et al. https://github.com/galaxyproteomics/
 
   </help>
 </tool>

--- a/tools/msconvert/msconvert_wrapper.py
+++ b/tools/msconvert/msconvert_wrapper.py
@@ -207,6 +207,7 @@ def run_script():
     parser = optparse.OptionParser()
     parser.add_option('--input', dest='inputs', action='append', default=[])
     parser.add_option('--input_name', dest='input_names', action='append', default=[])
+    parser.add_option('--implicit', dest='implicits', action='append', default=[], help='input files that should NOT be on the msconvert command line.')
     parser.add_option('--output', dest='output')
     parser.add_option('--fromextension', dest='fromextension')
     parser.add_option('--toextension', dest='toextension', default='mzML', choices=to_extensions)
@@ -239,7 +240,7 @@ def run_script():
         if not input_base:
             input_base = 'input%s' % i
             print("2- input_base: %s" % input_base)
-        if not input_base.lower().endswith(options.fromextension.lower()):
+        if not input_base.lower().endswith(options.fromextension.lower()) and input not in options.implicits:
             input_file = '%s.%s' % (input_base, options.fromextension)
             print("3- input_base: %s" % input_base)
             print("3- input_file: %s" % input_file)
@@ -249,6 +250,8 @@ def run_script():
             print("4- input_file: %s" % input_file)
         input_file = input_file
         copy_to_working_directory(input, input_file)
+        if input in options.implicits:
+            continue
         input_files.append(input_file)
 
     cmd = _build_base_cmd(options)

--- a/tools/msconvert/msconvert_wrapper.py
+++ b/tools/msconvert/msconvert_wrapper.py
@@ -250,9 +250,8 @@ def run_script():
             print("4- input_file: %s" % input_file)
         input_file = input_file
         copy_to_working_directory(input, input_file)
-        if input in options.implicits:
-            continue
-        input_files.append(input_file)
+        if input not in options.implicits:
+            input_files.append(input_file)
 
     cmd = _build_base_cmd(options)
     file_column = options.filter_table_file_column


### PR DESCRIPTION
Did the minimal to add conversion of wiff datasets.   
This relies on the Wiff datatype having files named wiff and wiff_scan in the extra_files_path, 
and requires the input_names to have the .wiff and .wiff.scan extensions.
The option --implicit was added to  msconvert_wrapper.py in order to include the .wiff.scan file in the correct directory/filename but not to add it to the mscovert application command line.
