### PR TITLE
Fix precursor mass switch when using Daltons

### DIFF
--- a/tools/peptideshaker/macros.xml
+++ b/tools/peptideshaker/macros.xml
@@ -30,7 +30,7 @@
         <param name="precursor_ion_tol_units" type="select" label="Precursor Ion Tolerance Units"
             help="Select based on instrument used, as different machines provide different quality of spectra. ppm is a standard for most precursor ions">
             <option value="1">Parts per million (ppm)</option>
-            <option value="0">Daltons</option>
+            <option value="2">Daltons</option>
         </param>
         <param name="precursor_ion_tol" type="float" value="10" label="Percursor Ion Tolerance"
             help="Provide error value for precursor ion, based on instrument used. 10 ppm recommended for Orbitrap instrument"/>


### PR DESCRIPTION
Trivial fix for those of us who still use old instruments