### PR TITLE
Update peptideshaker to SearchGUI 2.1 and PeptideShaker 1.1

### DIFF
--- a/packages/package_morpheus_171/tool_dependencies.xml
+++ b/packages/package_morpheus_171/tool_dependencies.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="mono" version="4.0">
+       <repository name="package_mono_4_0" owner="iuc" prior_installation_required="True" />
+    </package>
+    <package name="morpheus" version="171">
+        <install version="1.0">
+            <actions>
+                <action type="download_by_url" >http://sourceforge.net/projects/morpheus-ms/files/revision%20171/Morpheus%20%28Linux%29.tar.gz</action>
+                <action type="set_environment_for_install">
+                    <repository name="package_mono_4_0" owner="iuc">
+                        <package name="mono" version="4.0" />
+                    </repository>
+                </action>
+                <action type="move_directory_files">
+                    <source_directory>Morpheus (Linux)</source_directory>
+                    <destination_directory>$INSTALL_DIR/</destination_directory>
+                </action>
+                <action type="set_environment">
+                    <environment_variable name="MORPHEUS_PATH" action="set_to">$INSTALL_DIR</environment_variable>
+                    <environment_variable name="PATH" action="prepend_to">$ENV[MONO_ROOT_PATH]/bin</environment_variable>
+                    <environment_variable name="LD_LIBRARY_PATH" action="prepend_to">$ENV[MONO_ROOT_PATH]/lib</environment_variable>
+                    <environment_variable name="MONO_ROOT_PATH" action="set_to">$ENV[MONO_ROOT_PATH]</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>
+            Install Galaxy package application for Morpheus release 171 for use on linux 
+            Must be executed with mono:
+            mono ${MORPHEUS_PATH}/morpheus_cl.exe -d input.mzML -db searchDB.fasta
+            http://morpheus-ms.sourceforge.net/
+        </readme>
+    </package>
+</tool_dependency>

--- a/packages/package_peptideshaker_1_1/tool_dependencies.xml
+++ b/packages/package_peptideshaker_1_1/tool_dependencies.xml
@@ -5,7 +5,7 @@
         <actions>
             <action type="download_by_url">http://genesis.ugent.be/maven2/eu/isas/peptideshaker/PeptideShaker/1.1.1/PeptideShaker-1.1.1.zip</action>
             <action type="move_directory_files">
-                <source_directory>.</source_directory>
+                <source_directory>PeptideShaker-1.1.1</source_directory>
                 <destination_directory>$INSTALL_DIR/</destination_directory>
             </action>
             <action type="set_environment">

--- a/tools/morpheus/morpheus.xml
+++ b/tools/morpheus/morpheus.xml
@@ -1,0 +1,197 @@
+<tool id="morpheus" name="Morpheus" version="1.171.1">
+    <description>database search algorithm for high-resolution tandem mass spectra</description>
+    <macros>
+        <xml name="modification_options">
+            <option value="carbamidomethylation of C">carbamidomethylation of C</option>
+            <option value="oxidation of M">oxidation of M</option>
+            <option value="acetylation of protein N-terminus">acetylation of protein N-terminus</option>
+            <option value="acetylation of lysine">acetylation of lysine</option>
+            <option value="phosphorylation of S">phosphorylation of S</option>
+            <option value="phosphorylation of T">phosphorylation of T</option>
+            <option value="phosphorylation of Y">phosphorylation of Y</option>
+            <option value="deamidation of N">deamidation of N</option>
+            <option value="deamidation of Q">deamidation of Q</option>
+            <option value="pyro-cmC">pyro-cmC</option>
+            <option value="pyro-E">pyro-E</option>
+            <option value="pyro-Q">pyro-Q</option>
+            <option value="TMT zero on peptide N-terminus">TMT zero on peptide N-terminus</option>
+            <option value="TMT zero on K">TMT zero on K</option>
+            <option value="TMT zero on Y">TMT zero on Y</option>
+            <option value="TMT duplex on peptide N-terminus">TMT duplex on peptide N-terminus</option>
+            <option value="TMT duplex on K">TMT duplex on K</option>
+            <option value="TMT duplex on Y">TMT duplex on Y</option>
+            <option value="TMT sixplex/tenplex on peptide N-terminus">TMT sixplex/tenplex on peptide N-terminus</option>
+            <option value="TMT sixplex/tenplex on K">TMT sixplex/tenplex on K</option>
+            <option value="TMT sixplex/tenplex on Y">TMT sixplex/tenplex on Y</option>
+            <option value="iTRAQ 4-plex on peptide N-terminus">iTRAQ 4-plex on peptide N-terminus</option>
+            <option value="iTRAQ 4-plex on K">iTRAQ 4-plex on K</option>
+            <option value="iTRAQ 4-plex on Y">iTRAQ 4-plex on Y</option>
+            <option value="iTRAQ 8-plex on peptide N-terminus">iTRAQ 8-plex on peptide N-terminus</option>
+            <option value="iTRAQ 8-plex on K">iTRAQ 8-plex on K</option>
+            <option value="iTRAQ 8-plex on Y    ">iTRAQ 8-plex on Y    </option>
+        </xml>
+    </macros>
+
+    <requirements>
+        <requirement version="4.0">mono</requirement>
+        <requirement version="171">morpheus</requirement>
+    </requirements>
+
+    <stdio>
+        <exit_code range="1:" />
+        <regex match="System..*Exception"
+           source="both"
+           level="fatal"
+           description="Error encountered" />
+    </stdio>
+
+    <command><![CDATA[
+        ln -s $input input.mzml
+        && mono \${MORPHEUS_PATH}/morpheus_cl.exe 
+        -d="input.mzml"
+        -db="$searchdb"
+        #if isinstance($searchdb.datatype, $__app__.datatypes_registry.get_datatype_by_extension('uniprotxml').__class__): 
+          #if str( $advanced.adv_options_selector) == "set":
+            $advance.noup
+          #end if
+        #end if
+        ## fm vm fdr mvmi precmt precmtv precmtu
+        #if  str($fdr):
+            -fdr=$fdr
+        #end if
+        #if  str($mvmi):
+            -mvmi=$mvmi
+        #end if
+        #if  str($precmt):
+            -precmt=$precmt
+        #end if
+        #if  str($precmtv):
+            -precmtv=$precmtv
+        #end if
+        #if  str($precmtu):
+            -precmtu=$precmtu
+        #end if
+        #if str( $advanced.adv_options_selector) == "set":
+            #if  str($advanced.minprecz):
+                -minprecz=$advanced.minprecz
+            #end if
+            #if  str($advanced.maxprecz):
+                -maxprecz=$advanced.maxprecz
+            #end if
+            #if  str($advanced.at):
+                -at=$advanced.at
+            #end if
+            #if  str($advanced.rt):
+                -rt=$advanced.rt
+            #end if
+            #if  str($advanced.mp):
+                -mp=$advanced.mp
+            #end if
+            #if  str($advanced.mmc):
+                -mmc=$advanced.mmc
+            #end if
+            #if  str($advanced.prodmt):
+                -prodmt=$advanced.prodmt
+            #end if
+            #if  str($advanced.prodmtu):
+                -prodmtu=$advanced.prodmtu
+            #end if
+            #if  str($advanced.minpmo):
+                -minpmo=$advanced.minpmo
+            #end if
+            #if  str($advanced.maxpmo):
+                -maxpmo=$advanced.maxpmo
+            #end if
+            #if  str($advanced.prodmtv):
+                -prodmtv=$advanced.prodmtv
+            #end if
+            #if  str($advanced.imb):
+                -imb=$advanced.imb
+            #end if
+            $advanced.acs $advanced.di $advanced.ad $advanced.pmc $advanced.cmu $advanced.mmu
+        #end if
+        #if str($fm) != 'None':
+            #set $fmods = str($fm).replace(',',';')
+            -fm="$fmods"
+        #end if
+        #if str($vm) != 'None':
+            #set $vmods = str($vm).replace(',',';')
+            -vm="$vmods"
+        #end if
+        -mt=\${GALAXY_SLOTS:-4}
+        
+    ]]></command>
+    <inputs>
+        <param name="input" type="data" format="indexedmzML" label='Indexed mzML' />
+        <param name="searchdb" type="data" format="fasta,uniprotxml" label="MS Protein Search Database: UniProt Xml or Fasta"/>
+        <param name="fm" type="select" multiple="true" optional="true" label="Fixed Modifications">
+            <expand macro="modification_options" />
+        </param>
+        <param name="vm" type="select" multiple="true" optional="true" label="Variable Modifications">
+            <expand macro="modification_options" />
+        </param>
+        <param name="fdr" type="float" value="1" optional="true" min="0.0" max="100.0" label="FDR (Maximum False Discovery Rate percent)" />
+        <param name="mvmi" type="integer" value="1024" optional="true" min="0" label="Maximum Variable Modification Isoforms Per Peptide" />
+        <param name="precmt" type="select" optional="true" label="Precursor Mass Type">
+            <option value="Monoisotopic">Monoisotopic</option>
+            <option value="Average">Average</option>
+        </param>
+        <param name="precmtv" type="float" value="10." optional="true" label="Precursor Mass Tolerance Value" />
+        <param name="precmtu" type="select" optional="true" label="Precursor Mass Tolerance Units">
+            <option value="ppm" selected="true">ppm</option>
+            <option value="Da">Daltons</option>
+        </param>
+        <conditional name="advanced">
+            <param name="adv_options_selector" type="select" label="Set advanced options?" help="Provides additional controls">
+                <option value="set">Set</option>
+                <option value="do_not_set" selected="True">Do not set</option>
+            </param>
+            <when value="set">
+                <param name="noup" type="boolean" truevalue="" falsevalue="-noup=true" checked="True" label="Use G-PTM with Uniprot Proteome Search Databases" />
+                <param name="minprecz" type="integer" value="2" optional="true" label="Minimum Unknown Precursor Charge State" />
+                <param name="maxprecz" type="integer" value="4" optional="true" label="Maximum Unknown Precursor Charge State" />
+                <param name="at" type="float" value="" optional="true" min="0.0" label="Absolute MS/MS Intensity Threshold" />
+                <param name="rt" type="float" value="" optional="true" min="0.0" label="Relative MS/MS Intensity Threshold" />
+                <param name="mp" type="integer" value="" optional="true" min="-1" label="Maximum Number of MS/MS Peaks" help="to disable set to: -1"/>
+                <param name="acs" type="boolean" truevalue="-acs=true" falsevalue="-acs=false" checked="true" optional="true" label="Assign Charge States" />
+                <param name="di" type="boolean" truevalue="-di=true" falsevalue="-di=false" checked="true" optional="true" label="Deisotope" />
+                <param name="ad" type="boolean" truevalue="-ad=true" falsevalue="-ad=false" checked="false" optional="true" label="Append Decoys" />
+                <param name="mmc" type="integer" value="2" optional="true" min="0" max="20" label="Maximum Missed Cleavages" />
+                <param name="pmc" type="boolean" truevalue="-pmc=true" falsevalue="-pmc=false" checked="false" optional="true" label="Precursor Monoisotopic Peak Correction" />
+                <param name="minpmo" type="integer" value="" optional="true" label="Minimum Precursor Monoisotopic Peak Correction" />
+                <param name="maxpmo" type="integer" value="" optional="true" label="Maximum Precursor Monoisotopic Peak Correction" />
+                <param name="prodmtv" type="float" value="" optional="true" label="Product Mass Tolerance Value" />
+                <param name="prodmt" type="select" optional="true" label="Product Mass Type">
+                    <option value="Monoisotopic">Monoisotopic</option>
+                    <option value="Average">Average</option>
+                </param>
+                <param name="prodmtu" type="select" optional="true" label="Product Mass Tolerance Units">
+                    <option value="Da">Daltons</option>
+                    <option value="ppm">ppm</option>
+                </param>
+                <param name="imb" type="select" optional="true" label="Initiator Methionine Behavior">
+                    <option value="Variable">Variable</option>
+                    <option value="Retain">Retain</option>
+                    <option value="Cleave">Cleave</option>
+                </param>
+                <param name="cmu" type="boolean" truevalue="-cmu=true" falsevalue="-cmu=false" checked="false" optional="true" label="Consider Modifications Unique" />
+                <param name="mmu" type="boolean" truevalue="-mmu=true" falsevalue="-mmu=false" checked="false" optional="true" label="Minimize Memory Usage" />
+            </when>
+            <when value="do_not_set"/>
+        </conditional>
+    </inputs>
+    <outputs>
+        <data name="summary" format="txt" label="${input.name.rsplit('.',1)[0]} summary.txt" from_work_dir="summary.txt" />
+        <data name="log" format="txt" label="${input.name.rsplit('.',1)[0]}.log.txt" from_work_dir="input.log.txt" />
+        <data name="output_psms" format="tabular" label="${input.name.rsplit('.',1)[0]}.PSMs.tsv" from_work_dir="input.PSMs.tsv" />
+        <data name="output_unique_peptides" format="tabular" label="${input.name.rsplit('.',1)[0]}.unique_peptides.tsv" from_work_dir="input.unique_peptides.tsv" />
+        <data name="output_protein_groups" format="tabular" label="${input.name.rsplit('.',1)[0]}.protein_groups.tsv" from_work_dir="input.protein_groups.tsv" />
+        <data name="output_pepxml" format="pepxml" label="${input.name.rsplit('.',1)[0]}.pep.xml" from_work_dir="input.pep.xml" />
+    </outputs>
+    <help><![CDATA[
+        TODO: Fill in help.
+    ]]></help>
+    <citations>
+        <citation type="doi">10.1021/pr301024c</citation>
+    </citations>
+</tool>

--- a/tools/morpheus/tool_dependencies.xml
+++ b/tools/morpheus/tool_dependencies.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="mono" version="4.0">
+       <repository name="package_mono_4_0" owner="iuc" />
+    </package>
+    <package name="morpheus" version="171">
+       <repository name="package_morpheus_171" owner="galaxyp" />
+    </package>
+</tool_dependency>

--- a/tools/peptideshaker/macros.xml
+++ b/tools/peptideshaker/macros.xml
@@ -26,7 +26,7 @@
             -ri $reverse_ion
     </token>
     <token name="@SEARCHGUI_MAJOR_VERSION@">2</token>
-    <token name="@SEARCH_GUI_VERION@">2.1</token>
+    <token name="@SEARCHGUI_VERSION@">2.1</token>
     <xml name="general_options">
         <param name="precursor_ion_tol_units" type="select" label="Precursor Ion Tolerance Units"
             help="Select based on instrument used, as different machines provide different quality of spectra. ppm is a standard for most precursor ions">

--- a/tools/peptideshaker/macros.xml
+++ b/tools/peptideshaker/macros.xml
@@ -25,7 +25,8 @@
             -fi $forward_ion
             -ri $reverse_ion
     </token>
-
+    <token name="@SEARCHGUI_MAJOR_VERSION@">2</token>
+    <token name="@SEARCH_GUI_VERION@">2.1</token>
     <xml name="general_options">
         <param name="precursor_ion_tol_units" type="select" label="Precursor Ion Tolerance Units"
             help="Select based on instrument used, as different machines provide different quality of spectra. ppm is a standard for most precursor ions">

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -33,7 +33,7 @@
             -sample '$samp_str'
             -replicate 1
             -identification_files \$cwd/searchgui_input.zip
-            -out \$cwd/peptideshaker_output.cps
+            -out \$cwd/peptideshaker_output.cpsx
             -zip \$cwd/peptideshaker_output.zip
 
             -threads "\${GALAXY_SLOTS:-12}"

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -1,4 +1,4 @@
-<tool id="peptide_shaker" name="Peptide Shaker" version="0.40.0">
+<tool id="peptide_shaker" name="Peptide Shaker" version="1.1.1">
     <description>
         Perform protein identification using various search engines based on results from SearchGUI
     </description>
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="0.40">peptide_shaker</requirement>
+        <requirement type="package" version="1.1">peptide_shaker</requirement>
     </requirements>
     <expand macro="stdio" />
     <command>
@@ -166,7 +166,12 @@
     </command>
     <inputs>
         <param name="searchgui_input" format="searchgui_archive" type="data" label="Compressed SearchGUI results"
-            help="SearchGUI Results from History"/>
+            help="SearchGUI Results from History">
+            <options options_filter_attribute="metadata.searchgui_major_version" >
+                <filter type="add_value" value="@SEARCHGUI_MAJOR_VERSION@" />
+            </options>
+            <validator type="expression" message="This version of PeptideShaker will only work with SearchGUI version: @SEARCHGUI_MAJOR_VERSION@ .">value is not None and value.metadata.searchgui_major_version == "@SEARCHGUI_MAJOR_VERSION@"</validator>
+        </param>
 
         <conditional name="species_type">
             <param name="species_type_selector" type="select" optional="true" label="The species type to use for the gene annotation"

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -1,4 +1,4 @@
-<tool id="search_gui" name="Search GUI" version="2.1.1">
+<tool id="search_gui" name="Search GUI" version="@SEARCHGUI_VERSION@.1">
     <description>
         Perform protein identification using various search engines and prepare results for input to Peptide Shaker
     </description>
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="2.1">searchgui</requirement>
+        <requirement type="package" version="@SEARCHGUI_VERSION@">searchgui</requirement>
         <environment_variable name="LC_ALL" action="set_to">C</environment_variable>        
     </requirements>
     <expand macro="stdio" />

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -1,4 +1,4 @@
-<tool id="search_gui" name="Search GUI" version="1.28.0">
+<tool id="search_gui" name="Search GUI" version="2.1.1">
     <description>
         Perform protein identification using various search engines and prepare results for input to Peptide Shaker
     </description>
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="1.28">searchgui</requirement>
+        <requirement type="package" version="2.1">searchgui</requirement>
         <environment_variable name="LC_ALL" action="set_to">C</environment_variable>        
     </requirements>
     <expand macro="stdio" />
@@ -21,6 +21,9 @@
         mkdir output_reports;
         cwd=`pwd`;
         export HOME=\$cwd;
+
+        # Create a searchgui.properties file for the version, which will be added to the searchgui_results if not already present
+        echo "searchgui.version=@SEARCHGUI_VERSION@" >> searchgui.properties;
 
         cp -r "\${SEARCHGUI_JAR_PATH%/*}" bin;
         tmp_searchgui_jar_path=`echo "\$cwd/bin/\${SEARCHGUI_JAR_PATH\#\#/*/}"`;
@@ -327,6 +330,10 @@
         &&
 
         (mv output/searchgui_out.zip searchgui_out.zip 2>> $temp_stderr)
+
+        &&
+
+        (zip -u searchgui_out.zip searchgui.properties 2>> $temp_stderr)
 
         &&
 

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -22,7 +22,7 @@
         cwd=`pwd`;
         export HOME=\$cwd;
 
-        # Create a searchgui.properties file for the version, which will be added to the searchgui_results if not already present
+        ##Create a searchgui.properties file for the version, which will be added to the searchgui_results if not already present
         echo "searchgui.version=@SEARCHGUI_VERSION@" >> searchgui.properties;
 
         cp -r "\${SEARCHGUI_JAR_PATH%/*}" bin;
@@ -51,7 +51,7 @@
         #####################################################
 
         (java -cp \$tmp_searchgui_jar_path eu.isas.searchgui.cmd.IdentificationParametersCLI
-            -out SEARCHGUI_IdentificationParameters.parameters
+            -out SEARCHGUI_IdentificationParameters.par
 
             @GENERAL_PARAMETERS@
 
@@ -171,6 +171,27 @@
                 -myrimatch_max_peak ${myrimatch.myrimatch_max_peak}                    
             #end if
 
+            #*
+            #if $andromeda.andromeda_advanced == "yes"
+                -andromeda_max_pep_mass ${andromeda.andromeda_max_pep_mass}
+                -andromeda_max_comb ${andromeda.andromeda_max_comb}
+                -andromeda_top_peaks ${andromeda.andromeda_top_peaks}
+                -andromeda_top_peaks_window ${andromeda.andromeda_top_peaks_window}
+                -andromeda_incl_water ${andromeda.andromeda_incl_water}
+                -andromeda_incl_ammonia ${andromeda.andromeda_incl_ammonia}
+                -andromeda_neutral_losses ${andromeda.andromeda_neutral_losses}
+                -andromeda_fragment_all ${andromeda.andromeda_fragment_all}
+                -andromeda_emp_correction ${andromeda.andromeda_emp_correction}
+                -andromeda_higher_charge ${andromeda.andromeda_higher_charge}
+                -andromeda_equal_il ${andromeda.andromeda_equal_il}
+                -andromeda_frag_method ${andromeda.andromeda_frag_method}
+                -andromeda_max_mods ${andromeda.andromeda_max_mods}
+                -andromeda_min_pep_length ${andromeda.andromeda_min_pep_length}
+                -andromeda_max_pep_length ${andromeda.andromeda_max_pep_length}
+                -andromeda_max_psms ${andromeda.andromeda_max_psms}
+            #end if
+            *#
+
             #if $tide.tide_advanced == "yes"
                 -tide_num_ptms ${tide.tide_num_ptms}
                 -tide_num_ptms_per_type ${tide.tide_num_ptms_per_type}
@@ -259,7 +280,7 @@
             -temp_folder `pwd`
             -spectrum_files \$cwd
             -output_folder \$cwd/output
-            -id_params SEARCHGUI_IdentificationParameters.parameters
+            -id_params SEARCHGUI_IdentificationParameters.par
 
             -threads "\${GALAXY_SLOTS:-12}"
 
@@ -319,6 +340,12 @@
                 -ms_amanda 0
             #end if
 
+            #if 'Andromeda' in $engines_list:
+                -andromeda 1
+            #else
+                -andromeda 0
+            #end if
+
             ## single zip file
             -output_option 0
 
@@ -364,6 +391,9 @@
             <option value="OMSSA" selected="True">OMSSA</option>
             <option value="Comet">Comet</option>
             <option value="Tide">Tide</option>
+            <!-- Windows only
+            <option value="Andromeda">Andromeda</option>
+            -->
             <validator type="no_options" message="Please select at least one output file" />
         </param>
 
@@ -786,6 +816,39 @@
                     label="MyriMatch: Maximum Peak Count" help="Maximum number of peaks to be used from a spectrum" />
             </when>
         </conditional>
+
+        <!-- Andromeda ADVANCED PARAMETERS -->
+        <!-- Windows only
+        <conditional name="andromeda">
+            <param name="andromeda_advanced" type="select" label="Andromeda Options">
+                <option value="yes">Advanced</option>
+                <option value="no" selected="True">Default</option>
+            </param>
+            <when value="no" />
+            <when value="yes">
+                <param name="andromeda_max_pep_mass" type="float" value="4600.0" label="Andromeda maximum peptide mass, default is: 4600.0" />
+                <param name="andromeda_max_comb" type="integer" value="250" label="Andromeda maximum combinations, default is: 250" />
+                <param name="andromeda_top_peaks" type="integer" value="8" label="Andromeda number of top peaks, default is: 8" />
+                <param name="andromeda_top_peaks_window" type="integer" value="100" label="Andromeda top peaks window width, default is: 100" />
+                <param name="andromeda_incl_water" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Andromeda account for water losses, default is: true" />
+                <param name="andromeda_incl_ammonia" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Andromeda account for ammonina losses, default is: true" />
+                <param name="andromeda_neutral_losses" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Andromeda neutral losses are sequence dependent, default is: true" />
+                <param name="andromeda_fragment_all" type="boolean" truevalue="1" falsevalue="0" checked="false" label="Andromeda fragment all option, default is: false" />
+                <param name="andromeda_emp_correction" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Andromeda emperical correction, default is: true" />
+                <param name="andromeda_higher_charge" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Andromeda higher charge option, default is: true" />
+                <param name="andromeda_equal_il" type="boolean" truevalue="1" falsevalue="0" checked="false" label="Andromeda whether I and L should be considered indistinguishable, default is: false" />
+                <param name="andromeda_frag_method" type="select" value="" label="Andromeda fragmentation method, (HCD, CID or EDT), default is: CID." >
+                   <option value="CID" selected="true">CID</option>
+                   <option value="HCD">HCD</option>
+                   <option value="EDT">EDT</option>
+                </param>
+                <param name="andromeda_max_mods" type="integer" value="5" label="Andromeda maximum number of modifications, default is: 5" />
+                <param name="andromeda_min_pep_length" type="integer" value="8" label="Andromeda minimum peptide length when using no enzyme, default is: 8" />
+                <param name="andromeda_max_pep_length" type="integer" value="25" label="Andromeda maximum peptide length when using no enzyme, default is: 25" />
+                <param name="andromeda_max_psms" type="integer" value="10" label="Andromeda maximum number of spectrum matches spectrum, default is: 10" />
+            </when>
+        </conditional>
+        -->
 
         <!-- Comet ADVANCED PARAMETERS -->
         <conditional name="comet">

--- a/tools/peptideshaker/tool_dependencies.xml
+++ b/tools/peptideshaker/tool_dependencies.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <tool_dependency>
-    <package name="searchgui" version="1.28">
-        <repository name="package_searchgui_1_28" owner="iracooke"/>
+    <package name="searchgui" version="2.1">
+        <repository name="package_searchgui_2_1" owner="iracooke"/>
     </package>
-    <package name="peptide_shaker" version="0.40">
-        <repository name="package_peptideshaker_0_40" owner="iracooke"/>
+    <package name="peptide_shaker" version="1.1">
+        <repository name="package_peptideshaker_1_1" owner="iracooke"/>
     </package>
 </tool_dependency>


### PR DESCRIPTION
This relies on a new binary SearchGUIArchive datatype in galaxy that would track versions in metadata.  
Should also remove repository_dependencies.xml  since datatypes are in main galaxy distribution,
We should also determine if searchgui_mods.loc.sample needs any updates.