### PR TITLE
- add standalone msgfplus wrapper that doesn't require protk

### DIFF
--- a/packages/package_msgfplus_v10089/.shed.yml
+++ b/packages/package_msgfplus_v10089/.shed.yml
@@ -1,6 +1,6 @@
 categories:
 - Tool Dependency Packages
-description: Contains a tool dependency definition that downloads the Bumbershoot tools.
+description: Contains a tool dependency definition that downloads the MS-GF+ MS/MS search engine.
 long_description: |
   MSGF+
 

--- a/packages/package_msgfplus_v10089/.shed.yml
+++ b/packages/package_msgfplus_v10089/.shed.yml
@@ -1,0 +1,11 @@
+categories:
+- Tool Dependency Packages
+description: Contains a tool dependency definition that downloads the Bumbershoot tools.
+long_description: |
+  MSGF+
+
+  http://proteomics.ucsd.edu/software-tools/ms-gf/
+name: package_msgfplus_v10089
+remote_repository_url: https://github.com/galaxyproteomics/tools-galaxyp/packages/package_msgfplus_v10089/
+owner: galaxyp
+type: tool_dependency_definition

--- a/packages/package_msgfplus_v10089/tool_dependencies.xml
+++ b/packages/package_msgfplus_v10089/tool_dependencies.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="msgfplus" version="v10089">
+        <install version="1.0">
+            <actions>
+                <action type="download_by_url">http://omics.pnl.gov/sites/default/files/software/MSGFPlus.20140716.zip</action>
+                <action type="move_file">
+                    <source>MSGFPlus.jar</source>
+                    <destination>$INSTALL_DIR</destination>
+                </action>
+                <action type="set_environment">
+                    <environment_variable name="PATH" action="prepend_to">$INSTALL_DIR</environment_variable>
+                </action>
+            </actions>
+        </install>
+        <readme>
+            This package downloads and installs MSGF+.
+        </readme>
+    </package>
+</tool_dependency>

--- a/tools/msgfplus/.shed.yml
+++ b/tools/msgfplus/.shed.yml
@@ -1,0 +1,11 @@
+owner: galaxyp
+name: msgfplus
+categories:
+- Proteomics
+description: MSGF+
+long_description: |
+  Identifies peptides in tandem mass spectra using the MSGF+ search engine.
+
+  http://proteomics.ucsd.edu/software-tools/ms-gf/
+remote_repository_url: https://github.com/galaxyproteomics/tools-galaxyp/tree/master/tools/msgfplus
+type: unrestricted

--- a/tools/msgfplus/COPYING
+++ b/tools/msgfplus/COPYING
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -1,0 +1,265 @@
+<tool id="msgfplus" name="MS-GF+" version="0.1">
+    <description>
+        Identifies peptides in tandem mass spectra using the MS-GF+ search engine.
+    </description>
+    <requirements>
+        <requirement type="package" version="10089">msgfplus</requirement>
+        <environment_variable name="LC_ALL" action="set_to">C</environment_variable>        
+    </requirements>
+    <stdio>
+        <exit_code range="1:" level="fatal" description="Job Failed" />
+        <regex match="java.*Exception" level="fatal" description="Java Exception"/> 
+        <regex match="Could not create the Java virtual machine" level="fatal" description="JVM Error"/>
+    </stdio>
+    <command>
+<![CDATA[
+        #set $db_name = $d.display_name.replace(".fasta", "") + ".fasta"
+        #set $input_name = $s.display_name
+        #set $output_name = $input_name.replace(".mzML", "") + ".mzid"
+        ln -s '$s' '${input_name}' &&
+        ln -s '$d' '${db_name}' &&
+
+        echo \\#Mods > Mods.txt &&
+        #set $common_mods = str($common_fixed_modifications) + "," + str($common_variable_modifications)
+        #for $mod in $common_mods.split(",")
+          echo '$mod.replace("_", ",")' >> Mods.txt &&
+        #end for
+
+        #for $mod in $custom_mods
+          echo '${mod.formula_or_mass},${mod.aa_specificity},${mod.fix_or_opt},${mod.position_specificity},${mod.mod_name}' >> Mods.txt &&
+        #end for
+
+        msgfjar=\$(which MSGFPlus.jar) &&
+        ( [ -f "\$msgfjar" ] || (echo MSGFPlus.jar not found && exit 1)) &&
+
+        java -jar \$msgfjar
+            -s '$input_name'
+            -d '$db_name'
+            -thread \${GALAXY_SLOTS:-1}
+            -mod Mods.txt
+            -tda $tda
+            -t $t$precursor_ion_tol_units
+            -ti $advanced.isotope_low,$advanced.isotope_high
+            -m $advanced.m
+            -inst $inst
+            -e $e
+            -protocol $advanced.protocol
+            -ntt $ntt
+            -minLength $advanced.minLength
+            -maxLength $advanced.maxLength
+            -minCharge $advanced.minCharge
+            -maxCharge $advanced.maxCharge
+            -n $advanced.n
+            -addFeatures $advanced.addFeatures
+        &&
+        mv '$output_name' output
+]]>
+    </command>
+    <inputs>
+        <param argument="-s" type="data" format="mzml" label="Input Raw MS File(s)"/>
+        <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
+        <param argument="-tda" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Search with on-the-fly decoy database?" help="MSGF+ uses XXX_ as an accession prefix to indicate a decoy hit" />
+        <param argument="-t" type="float" value="10" label="Precursor mass tolerance" help="Error tolerance for matching peptide mass to precursor ion mass"/>
+        <param name="precursor_ion_tol_units" type="select" label="Precursor mass tolerance units" help="Daltons are common for low-res instruments, ppm for high-res instruments">
+            <option value="ppm" selected="true">Parts per million (ppm)</option>
+            <option value="Da">Daltons</option>
+        </param>
+        <param argument="-inst" label="Instrument type" type="select" help="The instrument type that generated the MS/MS spectra is used to determine the scoring model">
+            <option value="0" selected="true">Low-res (LCQ/LTQ)</option>
+            <option value="1" >High-res (LTQ-Orbitrap)</option>
+            <option value="2" >Q-TOF</option>
+            <option value="3" >Q-Exactive</option>
+        </param>
+        <param argument="-e" type="select" label="Enzyme" help="Enzyme used to digest proteins in sample preparation; trypsin is the most commonly used enzyme">
+            <option value="0">Unspecific cleavage</option>
+            <option value="1" selected="true">Trypsin, no P rule</option>
+            <option value="2">Chymotrypsin, no P rule (FYWL)</option>
+            <option value="3">Lys-C, no P rule</option>
+            <option value="4">Lys-N</option>
+            <option value="5">Glu-C (glutamyl endopeptidase)</option>
+            <option value="6">Arg-C</option>
+            <option value="7">Asp-N</option>
+            <option value="8">Alpha-lytic protease</option>
+            <option value="9">No enzyme</option>
+        </param>
+        <param argument="-ntt" type="select" format="text" label="Number of tolerable termini" help="Semi-specific requires more time than fully specific; non-specific requires much more.">
+            <option value="2" selected="true">Fully specific (both termini match cleavage rules)</option>
+            <option value="1">Semi-specific (at least one terminus must match cleavage rules)</option>
+            <option value="0">Non-specific (neither terminus is required to match cleavage rules)</option>
+        </param>
+
+        <param name="common_fixed_modifications" type="select" label="Common Fixed Modifications" multiple="true" help="Occurs in known places on peptide sequence. Hold the appropriate key while clicking to select multiple items">
+            <option value="C2H3N1O1_C_fix_any_Carbamidomethyl" selected="true">Carbamidomethyl C</option>
+            <option value="144.102063_*_fix_N-term_iTRAQ4plex">iTRAQ 4-plex N-term</option>
+            <option value="144.102063_K_fix_any_iTRAQ4plex">iTRAQ 4-plex K</option>
+            <option value="225.155833_*_fix_N-term_TMT6plex">TMT 2-plex N-term</option>
+            <option value="225.155833_K_fix_any_TMT6plex">TMT 2-plex K</option>
+            <option value="229.162932_*_fix_N-term_TMT6plex">TMT 6-or-10-plex N-term</option>
+            <option value="229.162932_K_fix_any_TMT6plex">TMT 6-or-10-plex K</option>
+            <sanitizer invalid_char=""><valid initial="string.printable"><add value="["/><add value="]"/><add value=","/><add value="-"/></valid><mapping initial="none"></mapping></sanitizer>
+        </param>
+        <param name="common_variable_modifications" type="select" label="Common Variable Modifications" multiple="true" help="Can occur anywhere on the peptide sequence; adds additional error to search score. Hold the appropriate key while clicking to select multiple items">
+            <option value="C2H2O1_K_opt_any_Acetyl">Acetylation K</option>
+            <option value="C2H2O_*_opt_Prot-N-term_Acetyl">Acetylation Protein N-term</option>
+            <option value="C2H3NO_C_opt_any_Carbamidomethyl">Carbamidomethyl C</option>
+            <option value="C2H3NO_*_opt_N-term_Carbamidomethyl">Carbamidomethyl N-term</option>
+            <option value="H-1N-1O1_N_opt_any_Deamidated">Deamidation N</option>
+            <option value="H-1N-1O1_Q_opt_any_Deamidated">Deamidation Q</option>
+            <option value="CH2_K_opt_any_Methyl">Methylation K</option>
+            <option value="O1_M_opt_any_Oxidation" selected="true">Oxidation M</option>
+            <option value="HO3P_S_opt_any_Phospho">Phosphorylation S</option>
+            <option value="HO3P_T_opt_any_Phospho">Phosphorylation T</option>
+            <option value="HO3P_Y_opt_any_Phospho">Phosphorylation Y</option>
+            <option value="H-2O-1_E_opt_N-term_Glu-&gt;pyro-Glu">Pyro-glu from E</option>
+            <option value="H-3N-1_Q_opt_N-term_Gln-&gt;pyro-Glu">Pyro-glu from Q</option>
+            <sanitizer invalid_char=""><valid initial="string.printable"><add value="["/><add value="]"/><add value=","/><add value="-"/></valid><mapping initial="none"></mapping></sanitizer>
+        </param>
+        
+        <repeat name="custom_mods" title="Custom Modifications" help="Specify modifications with custom parameters">
+            <param name="formula_or_mass" type="text" label="Formula or Mass">
+                <sanitizer>
+                    <valid initial="string.digits">
+                        <add value="C"/>
+                        <add value="H"/>
+                        <add value="O"/>
+                        <add value="N"/>
+                        <add value="S"/>
+                        <add value="P"/>
+                        <add value="B"/><add value="r"/>
+                        <add value="C"/><add value="l"/>
+                        <add value="F"/><add value="e"/>
+                        <add value="S"/>
+                        <add value="."/>
+                        <add value="-"/>
+                    </valid>
+                </sanitizer>
+            </param>
+            <param name="aa_specificity" type="select" multiple="true" label="Amino Acid Specificity">
+                <option value="*" selected="true">Any</option>
+                <option value="A">A</option>
+                <option value="C">C</option>
+                <option value="D">D</option>
+                <option value="E">E</option>
+                <option value="F">F</option>
+                <option value="G">G</option>
+                <option value="H">H</option>
+                <option value="I">I</option>
+                <option value="K">K</option>
+                <option value="L">L</option>
+                <option value="M">M</option>
+                <option value="N">N</option>
+                <option value="P">P</option>
+                <option value="Q">Q</option>
+                <option value="R">R</option>
+                <option value="S">S</option>
+                <option value="T">T</option>
+                <option value="V">V</option>
+                <option value="W">W</option>
+                <option value="Y">Y</option>
+            </param>
+            <param name="fix_or_opt" type="select" label="Variable or Fixed?">
+                <option value="opt" selected="true">Variable</option>
+                <option value="fix">Fixed</option>
+            </param>
+            <param name="position_specificity" type="select" label="Positional Specificity">
+                <option value="any" selected="true">Any</option>
+                <option value="n-term">Peptide N-terminal</option>
+                <option value="c-term">Peptide C-terminal</option>
+                <option value="prot-n-term">Protein N-terminal</option>
+                <option value="prot-c-term">Protein C-terminal</option>
+            </param>
+            <param name="mod_name" type="text" label="Name" help="If this mod has an entry there in Unimod, this name should match its name there" />
+        </repeat>
+
+        <!-- MS-GF+ ADVANCED PARAMETERS -->
+        <section name="advanced" title="Advanced Options">
+            <param argument="-minCharge" label="Minimum precursor charge" value="2" type="integer" help="Minimum precursor charge to consider if charges are not specified in the spectrum file"/>
+            <param argument="-maxCharge" label="Maximum precursor charge" value="3" type="integer" help="Maximum precursor charge to consider if charges are not specified in the spectrum file"/>
+            <param argument="-minLength" label="Minimum peptide length" value="6" type="integer" help="Minimum peptide length to consider"/>
+            <param argument="-maxLength" label="Maximum peptide length" value="40" type="integer" help="Maximum peptide length to consider"/>
+            <param name="num_ptms" label="Maximum modifications allowed per peptide" type="integer" value="2" />
+            <param argument="-m" label="Fragmentation type" type="select" help="Fragmentation method identifier (used to determine the scoring model)">
+                <option value="0" selected="True">As written in the spectrum or CID if no info</option>
+                <option value="1" >CID</option>
+                <option value="2" >ETD</option>
+                <option value="3" >HCD</option>
+            </param>
+            <param argument="-protocol" label="Protocol type" type="select" help="Protocols are used to enable scoring parameters for enriched and/or labeled samples">
+                <option value="0" selected="True">Automatic</option>
+                <option value="1" >Phosphorylation</option>
+                <option value="2" >iTRAQ</option>
+                <option value="3" >iTRAQPhospho</option>
+                <option value="4" >TMT</option>
+                <option value="5" >Standard</option>
+            </param>
+            <param argument="-n" label="Maximum matches per spectrum" type="integer" value="1" help="Number of peptide matches per spectrum to report" />
+            <param argument="-addFeatures" label="Calculate additional scoring features?" type="boolean" truevalue="1" falsevalue="0" help="If true, several extra derivative scores are calculated for each match" />
+            <param name="isotope_low" label="Lower isotope error range" type="integer" value="0" help="Takes into account of the error introduced by chooosing a non-monoisotopic peak for fragmentation (-ti)" />
+            <param name="isotope_high" label="Upper isotope error range" type="integer" value="1" /> 
+        </section>
+    </inputs>
+    <outputs>
+        <data name="output" format="mzid" from_work_dir="output" />
+    </outputs>
+    <tests>
+        <test>
+            <param name="s" value="input/201208-378803.mzML" />
+            <param name="d" value="input/cow.protein.PRG2012-subset.fasta" />
+            <param name="tda" value="1" />
+            <param name="ntt" value="1" />
+            <param name="t" value="50" />
+            <param name="precursor_ion_tol_units" value="ppm" />            
+            <param name="common_fixed_modifications" value="" />
+            <param name="common_variable_modifications" value="" />
+            <output name="output" file="201208-378803-msgf-50ppm-semitryptic-no_mods.mzid" lines_diff="6" />
+        </test>
+        <test>
+            <param name="s" value="input/201208-378803.mzML" />
+            <param name="d" value="input/cow.protein.PRG2012-subset.fasta" />
+            <param name="tda" value="1" />
+            <param name="t" value="0.02" />
+            <param name="precursor_ion_tol_units" value="Da" />
+            <param name="isotope_low" value="-1" />
+            <param name="isotope_high" value="0" />
+            <param name="m" value="3" />
+            <param name="inst" value="2" />
+            <param name="e" value="3" />
+            <param name="protocol" value="2" />
+            <param name="minLength" value="10" />
+            <param name="maxLength" value="20" />
+            <param name="minCharge" value="2" />
+            <param name="maxCharge" value="6" />
+            <param name="n" value="2" />
+            <param name="addFeatures" value="1" />
+
+            <param name="common_fixed_modifications" value="C2H3N1O1_C_fix_any_Carbamidomethyl,144.102063_*_fix_N-term_iTRAQ4plex,144.102063_K_fix_any_iTRAQ4plex" />
+            <param name="common_variable_modifications" value="O1_M_opt_any_Oxidation,H-3N-1_Q_opt_N-term_Gln->pyro-Glu" />
+
+            <param name="custom_mods_0|formula_or_mass" value="C-2H-2O-2" />
+            <param name="custom_mods_0|aa_specificity" value="G" />
+            <param name="custom_mods_0|fix_or_opt" value="opt" />
+            <param name="custom_mods_0|position_specificity" value="c-term" />
+            <param name="custom_mods_0|mod_name" value="Gly-loss+Amide" />
+
+            <param name="custom_mods_1|formula_or_mass" value="C10H10N5O7P" />
+            <param name="custom_mods_1|aa_specificity" value="CS" />
+            <param name="custom_mods_1|fix_or_opt" value="opt" />
+            <param name="custom_mods_1|position_specificity" value="any" />
+            <param name="custom_mods_1|mod_name" value="cGMP" />
+
+            <output name="output" file="201208-378803-msgf-2mmu-tryptic-many_mods.mzid" lines_diff="6" />
+        </test>
+    </tests>
+    <help>
+**What it does**
+
+Performs protein identification via database search using MS-GF+.
+
+    </help>
+    <citations>
+        <citation type="doi">10.1038/ncomms6277</citation>
+        <citation type="doi">10.1021/pr8001244</citation>
+        <citation type="bibtex">@misc{toolsGalaxyP, author = {Chilton, J, Gruening, B, Chambers, MC, et al.}, title = {Galaxy Proteomics Tools}, publisher = {GitHub}, journal = {GitHub repository},
+                                      year = {2015}, url = {https://github.com/galaxyproteomics/tools-galaxyp}}</citation> <!-- TODO: fix substitution of commit ", commit = {$sha1$}" -->
+    </citations>
+</tool>

--- a/tools/msgfplus/test-data/201208-378803-msgf-2mmu-tryptic-many_mods.mzid
+++ b/tools/msgfplus/test-data/201208-378803-msgf-2mmu-tryptic-many_mods.mzid
@@ -1,0 +1,3039 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2015-11-09T22:47:09" >
+<cvList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <cv id="PSI-MS" uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.30.0" fullName="PSI-MS"/>
+    <cv id="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" fullName="UNIMOD"/>
+    <cv id="UO" uri="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo" fullName="UNIT-ONTOLOGY"/>
+</cvList>
+<AnalysisSoftwareList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <AnalysisSoftware version="Beta (v10089)" name="MS-GF+" id="ID_software">
+        <SoftwareName>
+            <cvParam accession="MS:1002048" cvRef="PSI-MS" name="MS-GF+"/>
+        </SoftwareName>
+    </AnalysisSoftware>
+</AnalysisSoftwareList>
+<SequenceCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <DBSequence accession="gi|30794280|ref|NP_851335.1|" searchDatabase_ref="SearchDB_1" length="607" id="DBSeq43937">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|30794280|ref|NP_851335.1| serum albumin precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528944676|ref|XP_005204734.1|" searchDatabase_ref="SearchDB_1" length="7610" id="DBSeq65480"/>
+    <DBSequence accession="gi|528968104|ref|XP_005212567.1|" searchDatabase_ref="SearchDB_1" length="815" id="DBSeq27657">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968104|ref|XP_005212567.1| PREDICTED: exocyst complex component 6B isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528968106|ref|XP_005212568.1|" searchDatabase_ref="SearchDB_1" length="811" id="DBSeq28473">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968106|ref|XP_005212568.1| PREDICTED: exocyst complex component 6B isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528968108|ref|XP_005212569.1|" searchDatabase_ref="SearchDB_1" length="766" id="DBSeq29285">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968108|ref|XP_005212569.1| PREDICTED: exocyst complex component 6B isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|115497338|ref|NP_001069884.1|" searchDatabase_ref="SearchDB_1" length="626" id="DBSeq37511">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|115497338|ref|NP_001069884.1| exocyst complex component 6B [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|358418103|ref|XP_600387.4|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq63026"/>
+    <DBSequence accession="XXX_gi|528923273|ref|XP_005196452.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq63881"/>
+    <DBSequence accession="XXX_gi|297488451|ref|XP_002696970.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq91148"/>
+    <DBSequence accession="XXX_gi|529000951|ref|XP_005222651.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq92003"/>
+    <DBSequence accession="XXX_gi|358414198|ref|XP_002700672.2|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq104353"/>
+    <DBSequence accession="XXX_gi|528966552|ref|XP_005211956.1|" searchDatabase_ref="SearchDB_1" length="1131" id="DBSeq107227"/>
+    <DBSequence accession="XXX_gi|528966554|ref|XP_005211957.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq108359"/>
+    <DBSequence accession="XXX_gi|297479727|ref|XP_002690982.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq109459"/>
+    <DBSequence accession="gi|358414198|ref|XP_002700672.2|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq48378">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|358414198|ref|XP_002700672.2| PREDICTED: LOW QUALITY PROTEIN: solute carrier family 12 member 1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528966552|ref|XP_005211956.1|" searchDatabase_ref="SearchDB_1" length="1131" id="DBSeq51252">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528966552|ref|XP_005211956.1| PREDICTED: solute carrier family 12 member 1 isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528966554|ref|XP_005211957.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq52384">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528966554|ref|XP_005211957.1| PREDICTED: solute carrier family 12 member 1 isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|297479727|ref|XP_002690982.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq53484">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|297479727|ref|XP_002690982.1| PREDICTED: solute carrier family 12 member 1 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528928354|ref|XP_005193233.1|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq64736"/>
+    <DBSequence accession="gi|528928354|ref|XP_005193233.1|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq8761">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528928354|ref|XP_005193233.1| PREDICTED: fibrous sheath-interacting protein 2-like [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528944678|ref|XP_005204735.1|" searchDatabase_ref="SearchDB_1" length="5498" id="DBSeq73091"/>
+    <DBSequence accession="XXX_gi|219804516|ref|NP_001137332.1|" searchDatabase_ref="SearchDB_1" length="5422" id="DBSeq94489"/>
+    <DBSequence accession="gi|528944676|ref|XP_005204734.1|" searchDatabase_ref="SearchDB_1" length="7610" id="DBSeq9505">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528944676|ref|XP_005204734.1| PREDICTED: microtubule-actin cross-linking factor 1 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528944678|ref|XP_005204735.1|" searchDatabase_ref="SearchDB_1" length="5498" id="DBSeq17116">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528944678|ref|XP_005204735.1| PREDICTED: microtubule-actin cross-linking factor 1 isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|219804516|ref|NP_001137332.1|" searchDatabase_ref="SearchDB_1" length="5422" id="DBSeq38514">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|219804516|ref|NP_001137332.1| microtubule-actin cross-linking factor 1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528953238|ref|XP_005208082.1|" searchDatabase_ref="SearchDB_1" length="206" id="DBSeq23283">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528953238|ref|XP_005208082.1| PREDICTED: alpha-S1-casein isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528953240|ref|XP_005208083.1|" searchDatabase_ref="SearchDB_1" length="206" id="DBSeq79465"/>
+    <DBSequence accession="gi|27806963|ref|NP_776953.1|" searchDatabase_ref="SearchDB_1" length="222" id="DBSeq46622">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|27806963|ref|NP_776953.1| alpha-S2-casein precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528993971|ref|XP_005219929.1|" searchDatabase_ref="SearchDB_1" length="768" id="DBSeq87068"/>
+    <DBSequence accession="XXX_gi|528993973|ref|XP_005219930.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq87837"/>
+    <DBSequence accession="XXX_gi|528993975|ref|XP_005219931.1|" searchDatabase_ref="SearchDB_1" length="685" id="DBSeq88550"/>
+    <DBSequence accession="XXX_gi|27806851|ref|NP_776358.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq103640"/>
+    <DBSequence accession="gi|528993971|ref|XP_005219929.1|" searchDatabase_ref="SearchDB_1" length="768" id="DBSeq31093">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528993971|ref|XP_005219929.1| PREDICTED: lactoperoxidase isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528993973|ref|XP_005219930.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq31862">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528993973|ref|XP_005219930.1| PREDICTED: lactoperoxidase isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|27806851|ref|NP_776358.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq47665">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|27806851|ref|NP_776358.1| lactoperoxidase precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528968106|ref|XP_005212568.1|" searchDatabase_ref="SearchDB_1" length="811" id="DBSeq84448"/>
+    <DBSequence accession="XXX_gi|528954392|ref|XP_005208526.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq79850"/>
+    <DBSequence accession="XXX_gi|115496708|ref|NP_001069831.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq102315"/>
+    <DBSequence accession="gi|528954392|ref|XP_005208526.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq23875">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528954392|ref|XP_005208526.1| PREDICTED: ubiquitin-60S ribosomal protein L40 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|115496708|ref|NP_001069831.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq46340">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|115496708|ref|NP_001069831.1| ubiquitin-60S ribosomal protein L40 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|30794280|ref|NP_851335.1|" searchDatabase_ref="SearchDB_1" length="607" id="DBSeq99912"/>
+    <DBSequence accession="XXX_gi|528953238|ref|XP_005208082.1|" searchDatabase_ref="SearchDB_1" length="206" id="DBSeq79258"/>
+    <DBSequence accession="XXX_gi|528968104|ref|XP_005212567.1|" searchDatabase_ref="SearchDB_1" length="815" id="DBSeq83632"/>
+    <DBSequence accession="XXX_gi|528968108|ref|XP_005212569.1|" searchDatabase_ref="SearchDB_1" length="766" id="DBSeq85260"/>
+    <DBSequence accession="XXX_gi|115497338|ref|NP_001069884.1|" searchDatabase_ref="SearchDB_1" length="626" id="DBSeq93486"/>
+    <DBSequence accession="gi|528908812|ref|XP_609847.5|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq3312">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908812|ref|XP_609847.5| PREDICTED: zinc finger protein 169 isoform X6 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959657|ref|XP_002689899.2|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq27068">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959657|ref|XP_002689899.2| PREDICTED: zinc finger protein 169 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528918160|ref|XP_005195085.1|" searchDatabase_ref="SearchDB_1" length="77" id="DBSeq3901">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528918160|ref|XP_005195085.1| PREDICTED: polyubiquitin-B-like [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528988998|ref|XP_005218033.1|" searchDatabase_ref="SearchDB_1" length="77" id="DBSeq30388">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528988998|ref|XP_005218033.1| PREDICTED: polyubiquitin-B-like [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528995061|ref|XP_005220351.1|" searchDatabase_ref="SearchDB_1" length="305" id="DBSeq33261">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528995061|ref|XP_005220351.1| PREDICTED: polyubiquitin-B isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528995063|ref|XP_005220352.1|" searchDatabase_ref="SearchDB_1" length="305" id="DBSeq33567">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528995063|ref|XP_005220352.1| PREDICTED: polyubiquitin-B isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|27806505|ref|NP_776558.1|" searchDatabase_ref="SearchDB_1" length="305" id="DBSeq44545">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|27806505|ref|NP_776558.1| polyubiquitin-B [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528995061|ref|XP_005220351.1|" searchDatabase_ref="SearchDB_1" length="305" id="DBSeq89236"/>
+    <DBSequence accession="XXX_gi|528995063|ref|XP_005220352.1|" searchDatabase_ref="SearchDB_1" length="305" id="DBSeq89542"/>
+    <DBSequence accession="XXX_gi|27806505|ref|NP_776558.1|" searchDatabase_ref="SearchDB_1" length="305" id="DBSeq100520"/>
+    <DBSequence accession="XXX_gi|329665078|ref|NP_001193236.1|" searchDatabase_ref="SearchDB_1" length="690" id="DBSeq101624"/>
+    <DBSequence accession="gi|329665078|ref|NP_001193236.1|" searchDatabase_ref="SearchDB_1" length="690" id="DBSeq45649">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|329665078|ref|NP_001193236.1| polyubiquitin-C [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <Peptide id="Pep1">
+        <PeptideSequence>PDPNTLCDEFKADEKKFWGK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="7">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="7">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="20">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep2">
+        <PeptideSequence>EIAEAVSLPGK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="7">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep3">
+        <PeptideSequence>QPFPKKFPFSEFVPK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="5">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="6">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep4">
+        <PeptideSequence>ESMKRALEYLRNRRK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="2">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="4">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep5">
+        <PeptideSequence>AMGSNMEKVCLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="2">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="8">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="10">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="12">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep6">
+        <PeptideSequence>LCVKEMNSGMAK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="2">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="4">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="6">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="8">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="12">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep7">
+        <PeptideSequence>KLSHNSMLPK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="1">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="7">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep8">
+        <PeptideSequence>PLMSNHSLKK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="3">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="4">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="9">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep9">
+        <PeptideSequence>RLYNWSILSK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep10">
+        <PeptideSequence>RLYNWSILSK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="9">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep11">
+        <PeptideSequence>RDDLLRQLLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep12">
+        <PeptideSequence>LLQRLLDDRK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep13">
+        <PeptideSequence>NLNEWANNMEDISKKVEPK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="9">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="13">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep14">
+        <PeptideSequence>PEVKKSIDEMNNAWENLNK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="4">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="5">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="10">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep15">
+        <PeptideSequence>LVSDANEQYK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="3">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep16">
+        <PeptideSequence>YQENADSVLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="7">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep17">
+        <PeptideSequence>QMEAESISSSEQKHIQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="2">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="17">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep18">
+        <PeptideSequence>QQAHIGEKMSHLRELQPVK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="8">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep19">
+        <PeptideSequence>EDHELCLQRTFVNK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="6">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep20">
+        <PeptideSequence>QEKNMAINPSK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="3">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep21">
+        <PeptideSequence>SFPQNPVELK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="1">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep22">
+        <PeptideSequence>TRGPAALSEEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="8">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep23">
+        <PeptideSequence>PFMIPFCNDGQICYEECQTK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="7">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="7">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="13">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="17">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="20">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep24">
+        <PeptideSequence>PFMIPFCNDGQICYEECQTK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="7">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="13">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="13">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="17">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="20">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep25">
+        <PeptideSequence>LHQEVCLCLQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="6">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="8">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="8">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep26">
+        <PeptideSequence>QLCLCVEQHLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="3">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="3">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="5">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="5">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep27">
+        <PeptideSequence>NEMAMCGSNVRQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="3">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="5">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="6">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep28">
+        <PeptideSequence>QRVNSGCMAMENK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="7">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="8">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="10">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep29">
+        <PeptideSequence>GRTRTAIRNGQVWEESLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="16">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep30">
+        <PeptideSequence>LPQGYHPNDVEEEWGK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep31">
+        <PeptideSequence>RFQAFMNNKRSTDKMK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="6">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="9">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="15">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep32">
+        <PeptideSequence>MKDTSRKNNMFAQFRK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="1">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="2">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="7">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="10">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep33">
+        <PeptideSequence>FLGRIGGNGEESENDK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="12">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep34">
+        <PeptideSequence>DNESEEGNGGIRGLFK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="4">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep35">
+        <PeptideSequence>RCNVARPHLRAYCK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="2">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="13">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="13">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep36">
+        <PeptideSequence>CYARLHPRAVNCRK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="1">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="1">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="12">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep37">
+        <PeptideSequence>MSHLRELQPVKYK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="1">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="2">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep38">
+        <PeptideSequence>ERMTEIKPLLCAGK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="7">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="11">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="11">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep39">
+        <PeptideSequence>QLCLCVEQHLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="3">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="5">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="5">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep40">
+        <PeptideSequence>QLCLCVEQHLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="3">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="3">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="5">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep41">
+        <PeptideSequence>ECCDKPLLEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="2">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="3">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="5">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="10">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep42">
+        <PeptideSequence>LKETSSFRMRHLQSLHK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="2">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="14">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="17">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep43">
+        <PeptideSequence>QESSSISEAEMQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="11">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep44">
+        <PeptideSequence>QMEAESISSSEQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="2">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep45">
+        <PeptideSequence>QEPERNECFLSHK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="8">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="8">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="11">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep46">
+        <PeptideSequence>HSLFCENREPEQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="2">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="5">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="5">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep47">
+        <PeptideSequence>LDSMSVDKIEERLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="3">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="5">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="8">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep48">
+        <PeptideSequence>LREEIKDVSMSDLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="6">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="9">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="11">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep49">
+        <PeptideSequence>VASLRETYGDMADCCEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="11">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="14">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="15">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="17">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep50">
+        <PeptideSequence>ECCDAMDGYTERLSAVK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="2">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="3">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="6">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="17">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep51">
+        <PeptideSequence>LQKVAHDLMEIEGEPAPDRK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="3">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="20">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep52">
+        <PeptideSequence>RDPAPEGEIEMLDHAVKQLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="17">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="20">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep53">
+        <PeptideSequence>RFQAFMNNKRSTDKMK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="9">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="11">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="15">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep54">
+        <PeptideSequence>SMENEDKEETVAK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="2">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="7">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep55">
+        <PeptideSequence>SRGVLSAVSSKSQILQEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep56">
+        <PeptideSequence>SRGVLSAVSSKSQILQEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="9">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep57">
+        <PeptideSequence>SRGVLSAVSSKSQILQEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="9">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep58">
+        <PeptideSequence>SRGVLSAVSSKSQILQEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="6">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="12">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep59">
+        <PeptideSequence>SRGVLSAVSSKSQILQEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="10">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="12">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep60">
+        <PeptideSequence>SRGVLSAVSSKSQILQEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="9">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="11">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="12">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep61">
+        <PeptideSequence>KSIDEMNNAWENLNK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="1">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="2">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="6">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep62">
+        <PeptideSequence>NLNEWANNMEDISKK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="15.99491463" location="9">
+            <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="13">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep63">
+        <PeptideSequence>VKESLDQLLEQYQTSK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="2">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="4">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="15">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep64">
+        <PeptideSequence>STQYQELLQDLSEKVK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="1">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="12">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="14">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="16">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep65">
+        <PeptideSequence>MAFRDVAVAFTQK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep66">
+        <PeptideSequence>ESTLHLVLRLRGGC</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="2">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="14">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="343.03178476" location="14">
+            <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep67">
+        <PeptideSequence>ILWAQKKAMGSNMEKVCLK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="6">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="7">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="15">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="17">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep68">
+        <PeptideSequence>LCVKEMNSGMAKKQAWLIK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="57.021463735" location="2">
+            <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="4">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="12">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="13">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep69">
+        <PeptideSequence>VFIQMGGRLRLVLHLTSEK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep70">
+        <PeptideSequence>ESTLHLVLRLRGGMQIFVK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="19">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <Peptide id="Pep71">
+        <PeptideSequence>QTVEAYSAAVQSQLQWMK</PeptideSequence>
+        <Modification monoisotopicMassDelta="144.102063" location="0">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="-17.026549105" location="0">
+            <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+        </Modification>
+        <Modification monoisotopicMassDelta="144.102063" location="18">
+            <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+        </Modification>
+    </Peptide>
+    <PeptideEvidence isDecoy="false" post="Y" pre="K" end="160" start="141" peptide_ref="Pep1" dBSequence_ref="DBSeq43937" id="PepEv_44077_1_141"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="5899" start="5889" peptide_ref="Pep2" dBSequence_ref="DBSeq65480" id="PepEv_71368_2_5889"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="496" start="482" peptide_ref="Pep3" dBSequence_ref="DBSeq27657" id="PepEv_28138_3_482"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="496" start="482" peptide_ref="Pep3" dBSequence_ref="DBSeq28473" id="PepEv_28954_3_482"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="496" start="482" peptide_ref="Pep3" dBSequence_ref="DBSeq29285" id="PepEv_29766_3_482"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="496" start="482" peptide_ref="Pep3" dBSequence_ref="DBSeq37511" id="PepEv_37992_3_482"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="278" start="264" peptide_ref="Pep4" dBSequence_ref="DBSeq63026" id="PepEv_63289_4_264"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="278" start="264" peptide_ref="Pep4" dBSequence_ref="DBSeq63881" id="PepEv_64144_4_264"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="278" start="264" peptide_ref="Pep4" dBSequence_ref="DBSeq91148" id="PepEv_91411_4_264"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="278" start="264" peptide_ref="Pep4" dBSequence_ref="DBSeq92003" id="PepEv_92266_4_264"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="367" peptide_ref="Pep5" dBSequence_ref="DBSeq104353" id="PepEv_104719_5_367"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="367" peptide_ref="Pep5" dBSequence_ref="DBSeq107227" id="PepEv_107593_5_367"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="367" peptide_ref="Pep5" dBSequence_ref="DBSeq108359" id="PepEv_108725_5_367"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="367" peptide_ref="Pep5" dBSequence_ref="DBSeq109459" id="PepEv_109825_5_367"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="734" start="723" peptide_ref="Pep6" dBSequence_ref="DBSeq48378" id="PepEv_49100_6_723"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="766" start="755" peptide_ref="Pep6" dBSequence_ref="DBSeq51252" id="PepEv_52006_6_755"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="734" start="723" peptide_ref="Pep6" dBSequence_ref="DBSeq52384" id="PepEv_53106_6_723"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="734" start="723" peptide_ref="Pep6" dBSequence_ref="DBSeq53484" id="PepEv_54206_6_723"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="205" start="196" peptide_ref="Pep7" dBSequence_ref="DBSeq64736" id="PepEv_64931_7_196"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="394" start="385" peptide_ref="Pep8" dBSequence_ref="DBSeq8761" id="PepEv_9145_8_385"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="6578" start="6569" peptide_ref="Pep9" dBSequence_ref="DBSeq65480" id="PepEv_72048_9_6569"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="4468" start="4459" peptide_ref="Pep9" dBSequence_ref="DBSeq73091" id="PepEv_77549_9_4459"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="4468" start="4459" peptide_ref="Pep9" dBSequence_ref="DBSeq94489" id="PepEv_98947_9_4459"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="6578" start="6569" peptide_ref="Pep10" dBSequence_ref="DBSeq65480" id="PepEv_72048_10_6569"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="4468" start="4459" peptide_ref="Pep10" dBSequence_ref="DBSeq73091" id="PepEv_77549_10_4459"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="4468" start="4459" peptide_ref="Pep10" dBSequence_ref="DBSeq94489" id="PepEv_98947_10_4459"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="2180" start="2171" peptide_ref="Pep11" dBSequence_ref="DBSeq65480" id="PepEv_67650_11_2171"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="2110" start="2101" peptide_ref="Pep11" dBSequence_ref="DBSeq73091" id="PepEv_75191_11_2101"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="2110" start="2101" peptide_ref="Pep11" dBSequence_ref="DBSeq94489" id="PepEv_96589_11_2101"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="5441" start="5432" peptide_ref="Pep12" dBSequence_ref="DBSeq9505" id="PepEv_14936_12_5432"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="3399" start="3390" peptide_ref="Pep12" dBSequence_ref="DBSeq17116" id="PepEv_20505_12_3390"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="3323" start="3314" peptide_ref="Pep12" dBSequence_ref="DBSeq38514" id="PepEv_41827_12_3314"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="1379" start="1361" peptide_ref="Pep13" dBSequence_ref="DBSeq65480" id="PepEv_66840_13_1361"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="1309" start="1291" peptide_ref="Pep13" dBSequence_ref="DBSeq73091" id="PepEv_74381_13_1291"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="1309" start="1291" peptide_ref="Pep13" dBSequence_ref="DBSeq94489" id="PepEv_95779_13_1291"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="6251" start="6233" peptide_ref="Pep14" dBSequence_ref="DBSeq9505" id="PepEv_15737_14_6233"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="4209" start="4191" peptide_ref="Pep14" dBSequence_ref="DBSeq17116" id="PepEv_21306_14_4191"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="4133" start="4115" peptide_ref="Pep14" dBSequence_ref="DBSeq38514" id="PepEv_42628_14_4115"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="5805" start="5796" peptide_ref="Pep15" dBSequence_ref="DBSeq9505" id="PepEv_15300_15_5796"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3763" start="3754" peptide_ref="Pep15" dBSequence_ref="DBSeq17116" id="PepEv_20869_15_3754"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3687" start="3678" peptide_ref="Pep15" dBSequence_ref="DBSeq38514" id="PepEv_42191_15_3678"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="K" end="1816" start="1807" peptide_ref="Pep16" dBSequence_ref="DBSeq65480" id="PepEv_67286_16_1807"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="K" end="1746" start="1737" peptide_ref="Pep16" dBSequence_ref="DBSeq73091" id="PepEv_74827_16_1737"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="K" end="1746" start="1737" peptide_ref="Pep16" dBSequence_ref="DBSeq94489" id="PepEv_96225_16_1737"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="90" start="74" peptide_ref="Pep17" dBSequence_ref="DBSeq23283" id="PepEv_23356_17_74"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="K" end="87" start="69" peptide_ref="Pep18" dBSequence_ref="DBSeq79465" id="PepEv_79533_18_69"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="4200" start="4187" peptide_ref="Pep19" dBSequence_ref="DBSeq65480" id="PepEv_69666_19_4187"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="47" start="37" peptide_ref="Pep20" dBSequence_ref="DBSeq46622" id="PepEv_46658_20_37"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="426" start="417" peptide_ref="Pep21" dBSequence_ref="DBSeq9505" id="PepEv_9921_21_417"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="426" start="417" peptide_ref="Pep21" dBSequence_ref="DBSeq17116" id="PepEv_17532_21_417"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="350" start="341" peptide_ref="Pep21" dBSequence_ref="DBSeq38514" id="PepEv_38854_21_341"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3077" start="3067" peptide_ref="Pep22" dBSequence_ref="DBSeq9505" id="PepEv_12571_22_3067"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep23" dBSequence_ref="DBSeq87068" id="PepEv_87518_23_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep23" dBSequence_ref="DBSeq87837" id="PepEv_88287_23_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep23" dBSequence_ref="DBSeq88550" id="PepEv_89000_23_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep23" dBSequence_ref="DBSeq103640" id="PepEv_104090_23_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep24" dBSequence_ref="DBSeq87068" id="PepEv_87518_24_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep24" dBSequence_ref="DBSeq87837" id="PepEv_88287_24_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep24" dBSequence_ref="DBSeq88550" id="PepEv_89000_24_451"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="470" start="451" peptide_ref="Pep24" dBSequence_ref="DBSeq103640" id="PepEv_104090_24_451"/>
+    <PeptideEvidence isDecoy="true" post="M" pre="K" end="6763" start="6753" peptide_ref="Pep25" dBSequence_ref="DBSeq65480" id="PepEv_72232_25_6753"/>
+    <PeptideEvidence isDecoy="true" post="M" pre="K" end="4651" start="4641" peptide_ref="Pep25" dBSequence_ref="DBSeq73091" id="PepEv_77731_25_4641"/>
+    <PeptideEvidence isDecoy="true" post="M" pre="K" end="4651" start="4641" peptide_ref="Pep25" dBSequence_ref="DBSeq94489" id="PepEv_99129_25_4641"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="859" start="849" peptide_ref="Pep26" dBSequence_ref="DBSeq9505" id="PepEv_10353_26_849"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="859" start="849" peptide_ref="Pep26" dBSequence_ref="DBSeq17116" id="PepEv_17964_26_849"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="783" start="773" peptide_ref="Pep26" dBSequence_ref="DBSeq38514" id="PepEv_39286_26_773"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="2459" start="2447" peptide_ref="Pep27" dBSequence_ref="DBSeq65480" id="PepEv_67926_27_2447"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="2389" start="2377" peptide_ref="Pep27" dBSequence_ref="DBSeq73091" id="PepEv_75467_27_2377"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="2389" start="2377" peptide_ref="Pep27" dBSequence_ref="DBSeq94489" id="PepEv_96865_27_2377"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="5165" start="5153" peptide_ref="Pep28" dBSequence_ref="DBSeq9505" id="PepEv_14657_28_5153"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3123" start="3111" peptide_ref="Pep28" dBSequence_ref="DBSeq17116" id="PepEv_20226_28_3111"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3047" start="3035" peptide_ref="Pep28" dBSequence_ref="DBSeq38514" id="PepEv_41548_28_3035"/>
+    <PeptideEvidence isDecoy="false" post="R" pre="K" end="152" start="135" peptide_ref="Pep29" dBSequence_ref="DBSeq31093" id="PepEv_31227_29_135"/>
+    <PeptideEvidence isDecoy="false" post="R" pre="K" end="96" start="79" peptide_ref="Pep29" dBSequence_ref="DBSeq31862" id="PepEv_31940_29_79"/>
+    <PeptideEvidence isDecoy="false" post="R" pre="K" end="96" start="79" peptide_ref="Pep29" dBSequence_ref="DBSeq47665" id="PepEv_47743_29_79"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="483" start="468" peptide_ref="Pep30" dBSequence_ref="DBSeq9505" id="PepEv_9972_30_468"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="483" start="468" peptide_ref="Pep30" dBSequence_ref="DBSeq17116" id="PepEv_17583_30_468"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="407" start="392" peptide_ref="Pep30" dBSequence_ref="DBSeq38514" id="PepEv_38905_30_392"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="42" start="27" peptide_ref="Pep31" dBSequence_ref="DBSeq84448" id="PepEv_84474_31_27"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="786" start="771" peptide_ref="Pep32" dBSequence_ref="DBSeq28473" id="PepEv_29243_32_771"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="K" end="254" start="239" peptide_ref="Pep33" dBSequence_ref="DBSeq104353" id="PepEv_104591_33_239"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="K" end="254" start="239" peptide_ref="Pep33" dBSequence_ref="DBSeq107227" id="PepEv_107465_33_239"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="K" end="254" start="239" peptide_ref="Pep33" dBSequence_ref="DBSeq108359" id="PepEv_108597_33_239"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="K" end="254" start="239" peptide_ref="Pep33" dBSequence_ref="DBSeq109459" id="PepEv_109697_33_239"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="862" start="847" peptide_ref="Pep34" dBSequence_ref="DBSeq48378" id="PepEv_49224_34_847"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="894" start="879" peptide_ref="Pep34" dBSequence_ref="DBSeq51252" id="PepEv_52130_34_879"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="862" start="847" peptide_ref="Pep34" dBSequence_ref="DBSeq52384" id="PepEv_53230_34_847"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="862" start="847" peptide_ref="Pep34" dBSequence_ref="DBSeq53484" id="PepEv_54330_34_847"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="31" start="18" peptide_ref="Pep35" dBSequence_ref="DBSeq79850" id="PepEv_79867_35_18"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="31" start="18" peptide_ref="Pep35" dBSequence_ref="DBSeq102315" id="PepEv_102332_35_18"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="112" start="99" peptide_ref="Pep36" dBSequence_ref="DBSeq23875" id="PepEv_23973_36_99"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="112" start="99" peptide_ref="Pep36" dBSequence_ref="DBSeq46340" id="PepEv_46438_36_99"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="89" start="77" peptide_ref="Pep37" dBSequence_ref="DBSeq79465" id="PepEv_79541_37_77"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="K" end="411" start="398" peptide_ref="Pep38" dBSequence_ref="DBSeq99912" id="PepEv_100309_38_398"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="859" start="849" peptide_ref="Pep39" dBSequence_ref="DBSeq9505" id="PepEv_10353_39_849"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="859" start="849" peptide_ref="Pep39" dBSequence_ref="DBSeq17116" id="PepEv_17964_39_849"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="783" start="773" peptide_ref="Pep39" dBSequence_ref="DBSeq38514" id="PepEv_39286_39_773"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="859" start="849" peptide_ref="Pep40" dBSequence_ref="DBSeq9505" id="PepEv_10353_40_849"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="859" start="849" peptide_ref="Pep40" dBSequence_ref="DBSeq17116" id="PepEv_17964_40_849"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="783" start="773" peptide_ref="Pep40" dBSequence_ref="DBSeq38514" id="PepEv_39286_40_773"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="K" end="309" start="300" peptide_ref="Pep41" dBSequence_ref="DBSeq43937" id="PepEv_44236_41_300"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="760" start="744" peptide_ref="Pep42" dBSequence_ref="DBSeq9505" id="PepEv_10248_42_744"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="760" start="744" peptide_ref="Pep42" dBSequence_ref="DBSeq17116" id="PepEv_17859_42_744"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="684" start="668" peptide_ref="Pep42" dBSequence_ref="DBSeq38514" id="PepEv_39181_42_668"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="K" end="134" start="122" peptide_ref="Pep43" dBSequence_ref="DBSeq79258" id="PepEv_79379_43_122"/>
+    <PeptideEvidence isDecoy="false" post="H" pre="K" end="86" start="74" peptide_ref="Pep44" dBSequence_ref="DBSeq23283" id="PepEv_23356_44_74"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="130" start="118" peptide_ref="Pep45" dBSequence_ref="DBSeq43937" id="PepEv_44054_45_118"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="491" start="479" peptide_ref="Pep46" dBSequence_ref="DBSeq99912" id="PepEv_100390_46_479"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="627" start="614" peptide_ref="Pep47" dBSequence_ref="DBSeq83632" id="PepEv_84245_47_614"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="623" start="610" peptide_ref="Pep47" dBSequence_ref="DBSeq84448" id="PepEv_85057_47_610"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="578" start="565" peptide_ref="Pep47" dBSequence_ref="DBSeq85260" id="PepEv_85824_47_565"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="438" start="425" peptide_ref="Pep47" dBSequence_ref="DBSeq93486" id="PepEv_93910_47_425"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="203" start="190" peptide_ref="Pep48" dBSequence_ref="DBSeq27657" id="PepEv_27846_48_190"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="203" start="190" peptide_ref="Pep48" dBSequence_ref="DBSeq28473" id="PepEv_28662_48_190"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="203" start="190" peptide_ref="Pep48" dBSequence_ref="DBSeq29285" id="PepEv_29474_48_190"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="203" start="190" peptide_ref="Pep48" dBSequence_ref="DBSeq37511" id="PepEv_37700_48_190"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="117" start="101" peptide_ref="Pep49" dBSequence_ref="DBSeq43937" id="PepEv_44037_49_101"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="K" end="508" start="492" peptide_ref="Pep50" dBSequence_ref="DBSeq99912" id="PepEv_100403_50_492"/>
+    <PeptideEvidence isDecoy="false" post="H" pre="K" end="4123" start="4104" peptide_ref="Pep51" dBSequence_ref="DBSeq9505" id="PepEv_13608_51_4104"/>
+    <PeptideEvidence isDecoy="false" post="H" pre="K" end="2081" start="2062" peptide_ref="Pep51" dBSequence_ref="DBSeq17116" id="PepEv_19177_51_2062"/>
+    <PeptideEvidence isDecoy="false" post="H" pre="K" end="2005" start="1986" peptide_ref="Pep51" dBSequence_ref="DBSeq38514" id="PepEv_40499_51_1986"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="3508" start="3489" peptide_ref="Pep52" dBSequence_ref="DBSeq65480" id="PepEv_68968_52_3489"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="3438" start="3419" peptide_ref="Pep52" dBSequence_ref="DBSeq73091" id="PepEv_76509_52_3419"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="3438" start="3419" peptide_ref="Pep52" dBSequence_ref="DBSeq94489" id="PepEv_97907_52_3419"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="42" start="27" peptide_ref="Pep53" dBSequence_ref="DBSeq84448" id="PepEv_84474_53_27"/>
+    <PeptideEvidence isDecoy="false" post="M" pre="K" end="1125" start="1113" peptide_ref="Pep54" dBSequence_ref="DBSeq9505" id="PepEv_10617_54_1113"/>
+    <PeptideEvidence isDecoy="false" post="M" pre="K" end="1123" start="1111" peptide_ref="Pep54" dBSequence_ref="DBSeq17116" id="PepEv_18226_54_1111"/>
+    <PeptideEvidence isDecoy="false" post="M" pre="K" end="1047" start="1035" peptide_ref="Pep54" dBSequence_ref="DBSeq38514" id="PepEv_39548_54_1035"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6698" start="6681" peptide_ref="Pep55" dBSequence_ref="DBSeq65480" id="PepEv_72160_55_6681"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep55" dBSequence_ref="DBSeq73091" id="PepEv_77661_55_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep55" dBSequence_ref="DBSeq94489" id="PepEv_99059_55_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6698" start="6681" peptide_ref="Pep56" dBSequence_ref="DBSeq65480" id="PepEv_72160_56_6681"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep56" dBSequence_ref="DBSeq73091" id="PepEv_77661_56_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep56" dBSequence_ref="DBSeq94489" id="PepEv_99059_56_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6698" start="6681" peptide_ref="Pep57" dBSequence_ref="DBSeq65480" id="PepEv_72160_57_6681"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep57" dBSequence_ref="DBSeq73091" id="PepEv_77661_57_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep57" dBSequence_ref="DBSeq94489" id="PepEv_99059_57_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6698" start="6681" peptide_ref="Pep58" dBSequence_ref="DBSeq65480" id="PepEv_72160_58_6681"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep58" dBSequence_ref="DBSeq73091" id="PepEv_77661_58_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep58" dBSequence_ref="DBSeq94489" id="PepEv_99059_58_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6698" start="6681" peptide_ref="Pep59" dBSequence_ref="DBSeq65480" id="PepEv_72160_59_6681"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep59" dBSequence_ref="DBSeq73091" id="PepEv_77661_59_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep59" dBSequence_ref="DBSeq94489" id="PepEv_99059_59_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6698" start="6681" peptide_ref="Pep60" dBSequence_ref="DBSeq65480" id="PepEv_72160_60_6681"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep60" dBSequence_ref="DBSeq73091" id="PepEv_77661_60_4571"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4588" start="4571" peptide_ref="Pep60" dBSequence_ref="DBSeq94489" id="PepEv_99059_60_4571"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="6251" start="6237" peptide_ref="Pep61" dBSequence_ref="DBSeq9505" id="PepEv_15741_61_6237"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="4209" start="4195" peptide_ref="Pep61" dBSequence_ref="DBSeq17116" id="PepEv_21310_61_4195"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="4133" start="4119" peptide_ref="Pep61" dBSequence_ref="DBSeq38514" id="PepEv_42632_61_4119"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="1375" start="1361" peptide_ref="Pep62" dBSequence_ref="DBSeq65480" id="PepEv_66840_62_1361"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="1305" start="1291" peptide_ref="Pep62" dBSequence_ref="DBSeq73091" id="PepEv_74381_62_1291"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="1305" start="1291" peptide_ref="Pep62" dBSequence_ref="DBSeq94489" id="PepEv_95779_62_1291"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="2879" start="2864" peptide_ref="Pep63" dBSequence_ref="DBSeq65480" id="PepEv_68343_63_2864"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="2809" start="2794" peptide_ref="Pep63" dBSequence_ref="DBSeq73091" id="PepEv_75884_63_2794"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="K" end="2809" start="2794" peptide_ref="Pep63" dBSequence_ref="DBSeq94489" id="PepEv_97282_63_2794"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="4748" start="4733" peptide_ref="Pep64" dBSequence_ref="DBSeq9505" id="PepEv_14237_64_4733"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="2706" start="2691" peptide_ref="Pep64" dBSequence_ref="DBSeq17116" id="PepEv_19806_64_2691"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="K" end="2630" start="2615" peptide_ref="Pep64" dBSequence_ref="DBSeq38514" id="PepEv_41128_64_2615"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="-" end="13" start="1" peptide_ref="Pep65" dBSequence_ref="DBSeq3312" id="PepEv_3312_65_1"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="-" end="13" start="1" peptide_ref="Pep65" dBSequence_ref="DBSeq27068" id="PepEv_27068_65_1"/>
+    <PeptideEvidence isDecoy="false" post="-" pre="K" end="77" start="64" peptide_ref="Pep66" dBSequence_ref="DBSeq3901" id="PepEv_3964_66_64"/>
+    <PeptideEvidence isDecoy="false" post="-" pre="K" end="77" start="64" peptide_ref="Pep66" dBSequence_ref="DBSeq30388" id="PepEv_30451_66_64"/>
+    <PeptideEvidence isDecoy="false" post="-" pre="K" end="305" start="292" peptide_ref="Pep66" dBSequence_ref="DBSeq33261" id="PepEv_33552_66_292"/>
+    <PeptideEvidence isDecoy="false" post="-" pre="K" end="305" start="292" peptide_ref="Pep66" dBSequence_ref="DBSeq33567" id="PepEv_33858_66_292"/>
+    <PeptideEvidence isDecoy="false" post="-" pre="K" end="305" start="292" peptide_ref="Pep66" dBSequence_ref="DBSeq44545" id="PepEv_44836_66_292"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="360" peptide_ref="Pep67" dBSequence_ref="DBSeq104353" id="PepEv_104712_67_360"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="360" peptide_ref="Pep67" dBSequence_ref="DBSeq107227" id="PepEv_107586_67_360"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="360" peptide_ref="Pep67" dBSequence_ref="DBSeq108359" id="PepEv_108718_67_360"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="378" start="360" peptide_ref="Pep67" dBSequence_ref="DBSeq109459" id="PepEv_109818_67_360"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="741" start="723" peptide_ref="Pep68" dBSequence_ref="DBSeq48378" id="PepEv_49100_68_723"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="773" start="755" peptide_ref="Pep68" dBSequence_ref="DBSeq51252" id="PepEv_52006_68_755"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="741" start="723" peptide_ref="Pep68" dBSequence_ref="DBSeq52384" id="PepEv_53106_68_723"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="741" start="723" peptide_ref="Pep68" dBSequence_ref="DBSeq53484" id="PepEv_54206_68_723"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="91" start="73" peptide_ref="Pep69" dBSequence_ref="DBSeq89236" id="PepEv_89308_69_73"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="167" start="149" peptide_ref="Pep69" dBSequence_ref="DBSeq89236" id="PepEv_89384_69_149"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="243" start="225" peptide_ref="Pep69" dBSequence_ref="DBSeq89236" id="PepEv_89460_69_225"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="91" start="73" peptide_ref="Pep69" dBSequence_ref="DBSeq89542" id="PepEv_89614_69_73"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="167" start="149" peptide_ref="Pep69" dBSequence_ref="DBSeq89542" id="PepEv_89690_69_149"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="243" start="225" peptide_ref="Pep69" dBSequence_ref="DBSeq89542" id="PepEv_89766_69_225"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="91" start="73" peptide_ref="Pep69" dBSequence_ref="DBSeq100520" id="PepEv_100592_69_73"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="167" start="149" peptide_ref="Pep69" dBSequence_ref="DBSeq100520" id="PepEv_100668_69_149"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="243" start="225" peptide_ref="Pep69" dBSequence_ref="DBSeq100520" id="PepEv_100744_69_225"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="96" start="78" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_101701_69_78"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="172" start="154" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_101777_69_154"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="248" start="230" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_101853_69_230"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="324" start="306" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_101929_69_306"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="400" start="382" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_102005_69_382"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="476" start="458" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_102081_69_458"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="552" start="534" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_102157_69_534"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="K" end="628" start="610" peptide_ref="Pep69" dBSequence_ref="DBSeq101624" id="PepEv_102233_69_610"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="82" start="64" peptide_ref="Pep70" dBSequence_ref="DBSeq33261" id="PepEv_33324_70_64"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="158" start="140" peptide_ref="Pep70" dBSequence_ref="DBSeq33261" id="PepEv_33400_70_140"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="234" start="216" peptide_ref="Pep70" dBSequence_ref="DBSeq33261" id="PepEv_33476_70_216"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="82" start="64" peptide_ref="Pep70" dBSequence_ref="DBSeq33567" id="PepEv_33630_70_64"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="158" start="140" peptide_ref="Pep70" dBSequence_ref="DBSeq33567" id="PepEv_33706_70_140"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="234" start="216" peptide_ref="Pep70" dBSequence_ref="DBSeq33567" id="PepEv_33782_70_216"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="82" start="64" peptide_ref="Pep70" dBSequence_ref="DBSeq44545" id="PepEv_44608_70_64"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="158" start="140" peptide_ref="Pep70" dBSequence_ref="DBSeq44545" id="PepEv_44684_70_140"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="234" start="216" peptide_ref="Pep70" dBSequence_ref="DBSeq44545" id="PepEv_44760_70_216"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="82" start="64" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_45712_70_64"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="158" start="140" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_45788_70_140"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="234" start="216" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_45864_70_216"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="310" start="292" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_45940_70_292"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="386" start="368" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_46016_70_368"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="462" start="444" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_46092_70_444"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="538" start="520" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_46168_70_520"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="K" end="614" start="596" peptide_ref="Pep70" dBSequence_ref="DBSeq45649" id="PepEv_46244_70_596"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="848" start="831" peptide_ref="Pep71" dBSequence_ref="DBSeq9505" id="PepEv_10335_71_831"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="848" start="831" peptide_ref="Pep71" dBSequence_ref="DBSeq17116" id="PepEv_17946_71_831"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="772" start="755" peptide_ref="Pep71" dBSequence_ref="DBSeq38514" id="PepEv_39268_71_755"/>
+</SequenceCollection>
+<AnalysisCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <SpectrumIdentification spectrumIdentificationList_ref="SI_LIST_1" spectrumIdentificationProtocol_ref="SearchProtocol_1" id="SpecIdent_1">
+        <InputSpectra spectraData_ref="SID_1"/>
+        <SearchDatabaseRef searchDatabase_ref="SearchDB_1"/>
+    </SpectrumIdentification>
+</AnalysisCollection>
+<AnalysisProtocolCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <SpectrumIdentificationProtocol analysisSoftware_ref="ID_software" id="SearchProtocol_1">
+        <SearchType>
+            <cvParam accession="MS:1001083" cvRef="PSI-MS" name="ms-ms search"/>
+        </SearchType>
+        <AdditionalSearchParams>
+            <cvParam accession="MS:1001211" cvRef="PSI-MS" name="parent mass type mono"/>
+            <cvParam accession="MS:1001256" cvRef="PSI-MS" name="fragment mass type mono"/>
+            <userParam value="true" name="TargetDecoyApproach"/>
+            <userParam value="-1" name="MinIsotopeError"/>
+            <userParam value="0" name="MaxIsotopeError"/>
+            <userParam value="HCD" name="FragmentMethod"/>
+            <userParam value="QExactive" name="Instrument"/>
+            <userParam value="iTRAQ" name="Protocol"/>
+            <userParam value="2" name="NumTolerableTermini"/>
+            <userParam value="2" name="NumMatchesPerSpec"/>
+            <userParam value="2" name="MaxNumModifications"/>
+            <userParam value="10" name="MinPepLength"/>
+            <userParam value="20" name="MaxPepLength"/>
+            <userParam value="2" name="MinCharge"/>
+            <userParam value="6" name="MaxCharge"/>
+        </AdditionalSearchParams>
+        <ModificationParams>
+            <SearchModification residues="C" massDelta="57.021465" fixedMod="true">
+                <cvParam accession="UNIMOD:4" cvRef="UNIMOD" name="Carbamidomethyl"/>
+            </SearchModification>
+            <SearchModification residues="." massDelta="144.10207" fixedMod="true">
+                <SpecificityRules>
+                    <cvParam accession="MS:1001189" cvRef="PSI-MS" name="modification specificity N-term"/>
+                </SpecificityRules>
+                <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+            </SearchModification>
+            <SearchModification residues="K" massDelta="144.10207" fixedMod="true">
+                <cvParam accession="UNIMOD:214" cvRef="UNIMOD" name="iTRAQ4plex"/>
+            </SearchModification>
+            <SearchModification residues="M" massDelta="15.994915" fixedMod="false">
+                <cvParam accession="UNIMOD:35" cvRef="UNIMOD" name="Oxidation"/>
+            </SearchModification>
+            <SearchModification residues="Q" massDelta="-17.026548" fixedMod="false">
+                <SpecificityRules>
+                    <cvParam accession="MS:1001189" cvRef="PSI-MS" name="modification specificity N-term"/>
+                </SpecificityRules>
+                <cvParam accession="UNIMOD:28" cvRef="UNIMOD" name="Gln-&gt;pyro-Glu"/>
+            </SearchModification>
+            <SearchModification residues="G" massDelta="-58.005478" fixedMod="false">
+                <SpecificityRules>
+                    <cvParam accession="MS:1001190" cvRef="PSI-MS" name="modification specificity C-term"/>
+                </SpecificityRules>
+                <cvParam accession="UNIMOD:822" cvRef="UNIMOD" name="Gly-loss+Amide"/>
+            </SearchModification>
+            <SearchModification residues="C" massDelta="343.0318" fixedMod="false">
+                <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+            </SearchModification>
+            <SearchModification residues="S" massDelta="343.0318" fixedMod="false">
+                <cvParam accession="UNIMOD:849" cvRef="UNIMOD" name="cGMP"/>
+            </SearchModification>
+        </ModificationParams>
+        <Enzymes>
+            <Enzyme missedCleavages="1000" semiSpecific="false" id="LysC">
+                <EnzymeName>
+                    <cvParam accession="MS:1001309" cvRef="PSI-MS" name="Lys-C"/>
+                </EnzymeName>
+            </Enzyme>
+        </Enzymes>
+        <ParentTolerance>
+            <cvParam accession="MS:1001412" cvRef="PSI-MS" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" value="0.02" name="search tolerance plus value"/>
+            <cvParam accession="MS:1001413" cvRef="PSI-MS" unitCvRef="UO" unitName="dalton" unitAccession="UO:0000221" value="0.02" name="search tolerance minus value"/>
+        </ParentTolerance>
+        <Threshold>
+            <cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
+        </Threshold>
+    </SpectrumIdentificationProtocol>
+</AnalysisProtocolCollection>
+<DataCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <Inputs>
+        <SearchDatabase numDatabaseSequences="144" location="/tmp/tmpLUdxSj/job_working_directory/000/6/cow.protein.PRG2012-subset.fasta" id="SearchDB_1">
+            <FileFormat>
+                <cvParam accession="MS:1001348" cvRef="PSI-MS" name="FASTA format"/>
+            </FileFormat>
+            <DatabaseName>
+                <userParam name="cow.protein.PRG2012-subset.fasta"/>
+            </DatabaseName>
+            <cvParam accession="MS:1001197" cvRef="PSI-MS" name="DB composition target+decoy"/>
+            <cvParam accession="MS:1001283" cvRef="PSI-MS" value="^XXX" name="decoy DB accession regexp"/>
+            <cvParam accession="MS:1001195" cvRef="PSI-MS" name="decoy DB type reverse"/>
+        </SearchDatabase>
+        <SpectraData location="/tmp/tmpLUdxSj/job_working_directory/000/6/201208-378803.mzML" name="201208-378803.mzML" id="SID_1">
+            <FileFormat>
+                <cvParam accession="MS:1000584" cvRef="PSI-MS" name="mzML file"/>
+            </FileFormat>
+            <SpectrumIDFormat>
+                <cvParam accession="MS:1000770" cvRef="PSI-MS" name="WIFF nativeID format"/>
+            </SpectrumIDFormat>
+        </SpectraData>
+    </Inputs>
+    <AnalysisData>
+        <SpectrumIdentificationList id="SI_LIST_1">
+            <FragmentationTable>
+                <Measure id="Measure_MZ">
+                    <cvParam accession="MS:1001225" cvRef="PSI-MS" unitCvRef="PSI-MS" unitName="m/z" unitAccession="MS:1000040" name="product ion m/z"/>
+                </Measure>
+            </FragmentationTable>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1222 experiment=2" id="SIR_83">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep1" calculatedMassToCharge="582.2879638671875" experimentalMassToCharge="582.2852172851562" chargeState="6" id="SII_83_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44077_1_141"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-18" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="101" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.2806841E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="5.2595134" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="995.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep2" calculatedMassToCharge="582.2885131835938" experimentalMassToCharge="582.2852172851562" chargeState="3" id="SII_83_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_71368_2_5889"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-22" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="81" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.9369684E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="27.544622" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0020100502" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0020100502" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="995.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="4.328511" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="4.328511" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="4.328511" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="4.328511" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1214 experiment=4" id="SIR_60">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep3" calculatedMassToCharge="545.8862915039062" experimentalMassToCharge="545.8875732421875" chargeState="5" id="SII_60_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_28138_3_482"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_28954_3_482"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29766_3_482"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_37992_3_482"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-3" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="110" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.5377921E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="6.202992" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="2824.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep4" calculatedMassToCharge="545.8897094726562" experimentalMassToCharge="545.8875732421875" chargeState="5" id="SII_60_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63289_4_264"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_64144_4_264"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_91411_4_264"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_92266_4_264"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-19" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="110" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0030467864" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="122.898224" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="2824.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1207 experiment=2" id="SIR_35">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep5" calculatedMassToCharge="540.5006713867188" experimentalMassToCharge="540.2457885742188" chargeState="4" id="SII_35_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_104719_5_367"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_107593_5_367"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_108725_5_367"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_109825_5_367"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-10" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="88" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.7893981E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="7.1348667" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0025316456" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0025316456" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="790.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="15.702927" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="15.702927" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-15.702927" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-15.702927" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep6" calculatedMassToCharge="540.5006713867188" experimentalMassToCharge="540.2457885742188" chargeState="4" id="SII_35_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_49100_6_723"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_52006_6_755"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_53106_6_723"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_54206_6_723"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-12" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="88" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.7536333E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="10.979562" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="790.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1219 experiment=2" id="SIR_77">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep7" calculatedMassToCharge="487.2474365234375" experimentalMassToCharge="487.2433166503906" chargeState="4" id="SII_77_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_64931_7_196"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-11" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="65" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.9136534E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="7.5652456" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="2669.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep8" calculatedMassToCharge="487.2474365234375" experimentalMassToCharge="487.2433166503906" chargeState="4" id="SII_77_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9145_8_385"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-12" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="65" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.3838083E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="9.423909" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="2669.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1223 experiment=3" id="SIR_85">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep9" calculatedMassToCharge="478.4933776855469" experimentalMassToCharge="478.24365234375" chargeState="4" id="SII_85_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72048_9_6569"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77549_9_4459"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_98947_9_4459"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-13" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="69" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.3242636E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="9.188512" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="260.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep10" calculatedMassToCharge="478.4933776855469" experimentalMassToCharge="478.24365234375" chargeState="4" id="SII_85_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72048_10_6569"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77549_10_4459"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_98947_10_4459"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="69" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0012980293" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="51.314995" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="260.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1214 experiment=5" id="SIR_61">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep11" calculatedMassToCharge="519.994140625" experimentalMassToCharge="519.6590576171875" chargeState="3" id="SII_61_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_67650_11_2171"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_75191_11_2101"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_96589_11_2101"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-12" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.74489E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="10.851374" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.004137931" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.004137931" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="725.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="17.95661" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="17.95661" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="17.95661" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="17.95661" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep12" calculatedMassToCharge="519.994140625" experimentalMassToCharge="519.6590576171875" chargeState="3" id="SII_61_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_14936_12_5432"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_20505_12_3390"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_41827_12_3314"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-23" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.002920274" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="115.44719" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="725.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1580 experiment=2" id="SIR_106">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep13" calculatedMassToCharge="533.2630615234375" experimentalMassToCharge="533.2622680664062" chargeState="6" id="SII_106_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_66840_13_1361"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_74381_13_1291"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_95779_13_1291"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-28" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="48" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.8399474E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="11.622201" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="257.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep14" calculatedMassToCharge="533.2630615234375" experimentalMassToCharge="533.2622680664062" chargeState="6" id="SII_106_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15737_14_6233"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_21306_14_4191"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42628_14_4115"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-38" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="48" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0026143582" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="106.98999" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="257.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1200 experiment=3" id="SIR_22">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep15" calculatedMassToCharge="450.2066345214844" experimentalMassToCharge="450.2027587890625" chargeState="4" id="SII_22_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15300_15_5796"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_20869_15_3754"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42191_15_3678"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-11" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="54" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.3568923E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="13.2708025" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.001396648" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.001396648" name="CTermIonCurrentRatio"/>
+                    <userParam value="716.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="2.1449564" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="2.1449564" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-2.1449564" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-2.1449564" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep16" calculatedMassToCharge="450.2066345214844" experimentalMassToCharge="450.2027587890625" chargeState="4" id="SII_22_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_67286_16_1807"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_74827_16_1737"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_96225_16_1737"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="54" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.002777303" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="109.79513" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="716.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1212 experiment=4" id="SIR_52">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep17" calculatedMassToCharge="598.56005859375" experimentalMassToCharge="598.3059692382812" chargeState="4" id="SII_52_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_23356_17_74"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-18" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="68" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.2254035E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="17.16866" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="443.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep18" calculatedMassToCharge="598.3064575195312" experimentalMassToCharge="598.3059692382812" chargeState="5" id="SII_52_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79533_18_69"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-22" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="77" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.293104E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="21.661497" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="443.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=5" id="SIR_42">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep19" calculatedMassToCharge="404.1903381347656" experimentalMassToCharge="404.19219970703125" chargeState="6" id="SII_42_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_69666_19_4187"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-16" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="58" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.3619383E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="17.529322" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0051282053" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0051282053" name="CTermIonCurrentRatio"/>
+                    <userParam value="390.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="7.1713767" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="7.1713767" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-7.1713767" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-7.1713767" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep20" calculatedMassToCharge="404.3963623046875" experimentalMassToCharge="404.19219970703125" chargeState="5" id="SII_42_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46658_20_37"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-18" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="39" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0010095721" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="40.08708" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="390.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1210 experiment=2" id="SIR_43">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep21" calculatedMassToCharge="597.28857421875" experimentalMassToCharge="597.2890625" chargeState="3" id="SII_43_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9921_21_417"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17532_21_417"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38854_21_341"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-15" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="63" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.844457E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="23.104893" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="1322.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep22" calculatedMassToCharge="597.2872314453125" experimentalMassToCharge="597.2890625" chargeState="3" id="SII_43_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12571_22_3067"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-18" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="63" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0010981322" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="43.603535" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="7.564296E-4" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="7.564296E-4" name="CTermIonCurrentRatio"/>
+                    <userParam value="1322.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="10.069623" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="10.069623" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-10.069623" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-10.069623" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1201 experiment=4" id="SIR_26">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep23" calculatedMassToCharge="792.8295288085938" experimentalMassToCharge="792.8330078125" chargeState="4" id="SII_26_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_87518_23_451"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_88287_23_451"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89000_23_451"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_104090_23_451"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="80" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.935409E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="28.482338" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="121.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep24" calculatedMassToCharge="792.8295288085938" experimentalMassToCharge="792.8330078125" chargeState="4" id="SII_26_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_87518_24_451"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_88287_24_451"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89000_24_451"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_104090_24_451"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="80" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.935409E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="28.482338" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="121.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=4" id="SIR_41">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep25" calculatedMassToCharge="481.2019958496094" experimentalMassToCharge="481.1990051269531" chargeState="5" id="SII_41_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72232_25_6753"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77731_25_4641"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99129_25_4641"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="76" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.588521E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="30.13174" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="533.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep26" calculatedMassToCharge="481.2019958496094" experimentalMassToCharge="481.1990051269531" chargeState="5" id="SII_41_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10353_26_849"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17964_26_849"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39286_26_773"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-25" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="76" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.1667793E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="36.398533" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="533.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1210 experiment=3" id="SIR_44">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep27" calculatedMassToCharge="461.9718322753906" experimentalMassToCharge="461.7162170410156" chargeState="4" id="SII_44_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_67926_27_2447"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_75467_27_2377"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_96865_27_2377"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-17" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="57" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.840973E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="35.3913" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0044247787" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0044247787" name="CTermIonCurrentRatio"/>
+                    <userParam value="452.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="16.15865" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="16.15865" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="16.15865" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="16.15865" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep28" calculatedMassToCharge="461.9718322753906" experimentalMassToCharge="461.7162170410156" chargeState="4" id="SII_44_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_14657_28_5153"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_20226_28_3111"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_41548_28_3035"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-30" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="57" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.007912856" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="316.75952" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="452.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=3" id="SIR_55">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep29" calculatedMassToCharge="547.2781982421875" experimentalMassToCharge="547.2749633789062" chargeState="5" id="SII_55_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_31227_29_135"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_31940_29_79"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_47743_29_79"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="90" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.001027913" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="41.916237" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0031120332" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0031120332" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="964.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="9.420783" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="9.420783" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-9.420783" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-9.420783" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep30" calculatedMassToCharge="547.2743530273438" experimentalMassToCharge="547.2749633789062" chargeState="4" id="SII_55_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9972_30_468"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17583_30_468"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38905_30_392"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0028073182" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="113.65147" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0031120332" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0031120332" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="964.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="19.94787" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="19.94787" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-19.94787" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-19.94787" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1229 experiment=2" id="SIR_90">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep31" calculatedMassToCharge="522.8875732421875" experimentalMassToCharge="522.6893920898438" chargeState="5" id="SII_90_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84474_31_27"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-20" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="73" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0010280317" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="41.618835" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="817.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep32" calculatedMassToCharge="522.8875732421875" experimentalMassToCharge="522.6893920898438" chargeState="5" id="SII_90_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29243_32_771"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="73" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0012420963" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="50.285023" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="817.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1218 experiment=3" id="SIR_74">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep33" calculatedMassToCharge="471.414794921875" experimentalMassToCharge="471.2165222167969" chargeState="5" id="SII_74_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_104591_33_239"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_107465_33_239"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_108597_33_239"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_109697_33_239"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0014468122" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="58.572746" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="504.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep34" calculatedMassToCharge="471.414794921875" experimentalMassToCharge="471.2165222167969" chargeState="5" id="SII_74_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_49224_34_847"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_52130_34_879"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_53230_34_847"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_54330_34_847"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-45" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.024579557" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="995.0788" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="504.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1583 experiment=2" id="SIR_107">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep35" calculatedMassToCharge="487.2373962402344" experimentalMassToCharge="487.24053955078125" chargeState="5" id="SII_107_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79867_35_18"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_102332_35_18"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="50" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0014620319" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="58.754673" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="441.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep36" calculatedMassToCharge="487.2373962402344" experimentalMassToCharge="487.24053955078125" chargeState="5" id="SII_107_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_23973_36_99"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46438_36_99"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-33" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="50" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0052014035" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="209.0288" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="441.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1215 experiment=2" id="SIR_62">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep37" calculatedMassToCharge="605.8121948242188" experimentalMassToCharge="605.810546875" chargeState="4" id="SII_62_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79541_37_77"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-23" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="86" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0014706878" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="58.873104" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="486.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep38" calculatedMassToCharge="606.0590209960938" experimentalMassToCharge="605.810546875" chargeState="4" id="SII_62_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100309_38_398"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-27" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="86" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0029004393" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="116.55996" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="486.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1196 experiment=2" id="SIR_15">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep39" calculatedMassToCharge="409.19036865234375" experimentalMassToCharge="409.1874694824219" chargeState="5" id="SII_15_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10353_39_849"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17964_39_849"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39286_39_773"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-22" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0015165305" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="60.216877" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="465.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep40" calculatedMassToCharge="409.19036865234375" experimentalMassToCharge="409.1874694824219" chargeState="5" id="SII_15_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10353_40_849"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17964_40_849"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39286_40_773"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-23" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0018105983" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="71.893425" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="465.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=5" id="SIR_57">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep41" calculatedMassToCharge="575.3076171875" experimentalMassToCharge="575.3018188476562" chargeState="3" id="SII_57_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44236_41_300"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-22" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="59" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0015540735" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="61.437187" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0014619883" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0014619883" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="684.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="12.832601" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="12.832601" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="12.832601" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="12.832601" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep42" calculatedMassToCharge="575.5001220703125" experimentalMassToCharge="575.3018188476562" chargeState="5" id="SII_57_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10248_42_744"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17859_42_744"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39181_42_668"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-25" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="90" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0017753326" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="72.135315" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.00877193" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.00877193" name="CTermIonCurrentRatio"/>
+                    <userParam value="684.0" name="MS2IonCurrent"/>
+                    <userParam value="2" name="NumMatchedMainIons"/>
+                    <userParam value="11.25018" name="MeanErrorAll"/>
+                    <userParam value="5.709004" name="StdevErrorAll"/>
+                    <userParam value="11.25018" name="MeanErrorTop7"/>
+                    <userParam value="5.709004" name="StdevErrorTop7"/>
+                    <userParam value="5.7090044" name="MeanRelErrorAll"/>
+                    <userParam value="11.25018" name="StdevRelErrorAll"/>
+                    <userParam value="5.7090044" name="MeanRelErrorTop7"/>
+                    <userParam value="11.25018" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1191 experiment=2" id="SIR_8">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep43" calculatedMassToCharge="435.96044921875" experimentalMassToCharge="435.7113037109375" chargeState="4" id="SII_8_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79379_43_122"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-28" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.001760593" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="70.4783" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.044554457" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.03217822" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.012376238" name="CTermIonCurrentRatio"/>
+                    <userParam value="404.0" name="MS2IonCurrent"/>
+                    <userParam value="2" name="NumMatchedMainIons"/>
+                    <userParam value="19.003765" name="MeanErrorAll"/>
+                    <userParam value="0.682242" name="StdevErrorAll"/>
+                    <userParam value="19.003765" name="MeanErrorTop7"/>
+                    <userParam value="0.682242" name="StdevErrorTop7"/>
+                    <userParam value="-19.003765" name="MeanRelErrorAll"/>
+                    <userParam value="0.682242" name="StdevRelErrorAll"/>
+                    <userParam value="-19.003765" name="MeanRelErrorTop7"/>
+                    <userParam value="0.682242" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep44" calculatedMassToCharge="435.96044921875" experimentalMassToCharge="435.7113037109375" chargeState="4" id="SII_8_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_23356_44_74"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-36" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.005179537" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="207.34204" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="404.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1211 experiment=2" id="SIR_46">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep45" calculatedMassToCharge="442.1789855957031" experimentalMassToCharge="442.1819763183594" chargeState="6" id="SII_46_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44054_45_118"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-28" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="58" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.002249939" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="90.0673" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="558.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep46" calculatedMassToCharge="442.1789855957031" experimentalMassToCharge="442.1819763183594" chargeState="6" id="SII_46_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100390_46_479"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-31" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="58" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0036442573" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="145.88327" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="558.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1216 experiment=2" id="SIR_65">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep47" calculatedMassToCharge="464.3798522949219" experimentalMassToCharge="464.21527099609375" chargeState="6" id="SII_65_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84245_47_614"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85057_47_610"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85824_47_565"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_93910_47_425"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-25" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0023129396" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="92.9501" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="905.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep48" calculatedMassToCharge="464.3798522949219" experimentalMassToCharge="464.21527099609375" chargeState="6" id="SII_65_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27846_48_190"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_28662_48_190"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29474_48_190"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_37700_48_190"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-29" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0046383836" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="186.40273" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="905.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1218 experiment=2" id="SIR_73">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep49" calculatedMassToCharge="578.0166625976562" experimentalMassToCharge="577.770751953125" chargeState="4" id="SII_73_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44037_49_101"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="78" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.002549831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="103.60474" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="939.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep50" calculatedMassToCharge="578.0166625976562" experimentalMassToCharge="577.770751953125" chargeState="4" id="SII_73_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100403_50_492"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="78" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.025259368" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1026.3386" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="939.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=2" id="SIR_39">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep51" calculatedMassToCharge="452.25213623046875" experimentalMassToCharge="452.254638671875" chargeState="6" id="SII_39_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_13608_51_4104"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_19177_51_2062"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_40499_51_1986"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.002663105" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="109.3684" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="1024.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep52" calculatedMassToCharge="452.25213623046875" experimentalMassToCharge="452.254638671875" chargeState="6" id="SII_39_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_68968_52_3489"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_76509_52_3419"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_97907_52_3419"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.026686419" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1095.9579" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.001953125" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.001953125" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="1024.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="4.5456934" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="4.5456934" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="4.5456934" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="4.5456934" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1231 experiment=2" id="SIR_96">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep53" calculatedMassToCharge="490.4136657714844" experimentalMassToCharge="490.2488098144531" chargeState="6" id="SII_96_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84474_53_27"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="104" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0031199101" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="126.30644" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="611.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep54" calculatedMassToCharge="490.2491760253906" experimentalMassToCharge="490.2488098144531" chargeState="4" id="SII_96_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10617_54_1113"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_18226_54_1111"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39548_54_1035"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="72" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0040624393" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="162.6235" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="611.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1181 experiment=2" id="SIR_1">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep55" calculatedMassToCharge="506.7470397949219" experimentalMassToCharge="506.7447204589844" chargeState="6" id="SII_1_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72160_55_6681"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77661_55_4571"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99059_55_4571"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0035317831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="144.01906" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="159.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep56" calculatedMassToCharge="506.7470397949219" experimentalMassToCharge="506.7447204589844" chargeState="6" id="SII_1_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72160_56_6681"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77661_56_4571"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99059_56_4571"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0035317831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="144.01906" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="159.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="3" peptide_ref="Pep57" calculatedMassToCharge="506.7470397949219" experimentalMassToCharge="506.7447204589844" chargeState="6" id="SII_1_3">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72160_57_6681"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77661_57_4571"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99059_57_4571"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0035317831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="144.01906" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="159.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="4" peptide_ref="Pep58" calculatedMassToCharge="506.7470397949219" experimentalMassToCharge="506.7447204589844" chargeState="6" id="SII_1_4">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72160_58_6681"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77661_58_4571"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99059_58_4571"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0035317831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="144.01906" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="159.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="5" peptide_ref="Pep59" calculatedMassToCharge="506.7470397949219" experimentalMassToCharge="506.7447204589844" chargeState="6" id="SII_1_5">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72160_59_6681"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77661_59_4571"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99059_59_4571"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0035317831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="144.01906" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="159.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="6" peptide_ref="Pep60" calculatedMassToCharge="506.7470397949219" experimentalMassToCharge="506.7447204589844" chargeState="6" id="SII_1_6">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72160_60_6681"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77661_60_4571"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99059_60_4571"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0035317831" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="144.01906" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="159.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1203 experiment=3" id="SIR_30">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep61" calculatedMassToCharge="520.2421264648438" experimentalMassToCharge="520.2384033203125" chargeState="5" id="SII_30_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15741_61_6237"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_21310_61_4195"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42632_61_4119"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.004421605" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="178.35426" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="495.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep62" calculatedMassToCharge="520.2421264648438" experimentalMassToCharge="520.2384033203125" chargeState="5" id="SII_30_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_66840_62_1361"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_74381_62_1291"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_95779_62_1291"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-29" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="71" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.008392359" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="338.52258" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="495.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1228 experiment=3" id="SIR_89">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep63" calculatedMassToCharge="606.2780151367188" experimentalMassToCharge="606.2748413085938" chargeState="5" id="SII_89_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_68343_63_2864"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_75884_63_2794"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_97282_63_2794"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-33" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="75" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0046888194" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="189.82216" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="336.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep64" calculatedMassToCharge="606.2780151367188" experimentalMassToCharge="606.2748413085938" chargeState="5" id="SII_89_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_14237_64_4733"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_19806_64_2691"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_41128_64_2615"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-35" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="75" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0064314604" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="260.37125" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="336.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1283 experiment=2" id="SIR_104">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep65" calculatedMassToCharge="591.3304443359375" experimentalMassToCharge="591.3255615234375" chargeState="3" id="SII_104_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3312_65_1"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27068_65_1"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="85" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0048791072" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="195.31554" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="1072.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1223 experiment=2" id="SIR_84">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep66" calculatedMassToCharge="611.0167236328125" experimentalMassToCharge="610.7609252929688" chargeState="4" id="SII_84_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3964_66_64"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_30451_66_64"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33552_66_292"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33858_66_292"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44836_66_292"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-31" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="97" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.006540328" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="262.83615" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.008274232" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.008274232" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="846.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="13.573221" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="13.573221" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="13.573221" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="13.573221" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1281 experiment=2" id="SIR_103">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep67" calculatedMassToCharge="591.944091796875" experimentalMassToCharge="591.745361328125" chargeState="5" id="SII_103_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_104712_67_360"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_107586_67_360"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_108718_67_360"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_109818_67_360"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-35" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="110" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.009581658" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="392.11978" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="571.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep68" calculatedMassToCharge="591.944091796875" experimentalMassToCharge="591.745361328125" chargeState="5" id="SII_103_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_49100_68_723"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_52006_68_755"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_53106_68_723"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_54206_68_723"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="110" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.018137826" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="742.27234" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="571.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=2" id="SIR_54">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep69" calculatedMassToCharge="497.8994140625" experimentalMassToCharge="497.6971435546875" chargeState="5" id="SII_54_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89308_69_73"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89384_69_149"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89460_69_225"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89614_69_73"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89690_69_149"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89766_69_225"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100592_69_73"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100668_69_149"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100744_69_225"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_101701_69_78"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_101777_69_154"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_101853_69_230"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_101929_69_306"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_102005_69_382"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_102081_69_458"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_102157_69_534"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_102233_69_610"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-35" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="80" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.011701179" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="478.85904" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="1027.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep70" calculatedMassToCharge="497.8994140625" experimentalMassToCharge="497.6971435546875" chargeState="5" id="SII_54_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33324_70_64"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33400_70_140"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33476_70_216"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33630_70_64"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33706_70_140"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_33782_70_216"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44608_70_64"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44684_70_140"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44760_70_216"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_45712_70_64"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_45788_70_140"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_45864_70_216"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_45940_70_292"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46016_70_368"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46092_70_444"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46168_70_520"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46244_70_596"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-39" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="80" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.019098723" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="781.5961" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="9.7370986E-4" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="9.7370986E-4" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="1027.0" name="MS2IonCurrent"/>
+                    <userParam value="1" name="NumMatchedMainIons"/>
+                    <userParam value="1.8923733" name="MeanErrorAll"/>
+                    <userParam value="0.0" name="StdevErrorAll"/>
+                    <userParam value="1.8923733" name="MeanErrorTop7"/>
+                    <userParam value="0.0" name="StdevErrorTop7"/>
+                    <userParam value="-1.8923733" name="MeanRelErrorAll"/>
+                    <userParam value="0.0" name="StdevRelErrorAll"/>
+                    <userParam value="-1.8923733" name="MeanRelErrorTop7"/>
+                    <userParam value="0.0" name="StdevRelErrorTop7"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1428 experiment=2" id="SIR_105">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep71" calculatedMassToCharge="585.5540161132812" experimentalMassToCharge="585.301513671875" chargeState="4" id="SII_105_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10335_71_831"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17946_71_831"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39268_71_755"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-47" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="93" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.02323054" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="947.295" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="-1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                    <userParam value="0.0" name="ExplainedIonCurrentRatio"/>
+                    <userParam value="0.0" name="NTermIonCurrentRatio"/>
+                    <userParam value="0.0" name="CTermIonCurrentRatio"/>
+                    <userParam value="330.0" name="MS2IonCurrent"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+        </SpectrumIdentificationList>
+    </AnalysisData>
+</DataCollection>
+</MzIdentML>

--- a/tools/msgfplus/test-data/201208-378803-msgf-50ppm-semitryptic-no_mods.mzid
+++ b/tools/msgfplus/test-data/201208-378803-msgf-50ppm-semitryptic-no_mods.mzid
@@ -1,0 +1,2619 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<MzIdentML id="MS-GF+" version="1.1.0" xmlns="http://psidev.info/psi/pi/mzIdentML/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://psidev.info/psi/pi/mzIdentML/1.1 http://www.psidev.info/files/mzIdentML1.1.0.xsd" creationDate="2015-11-09T22:46:41" >
+<cvList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <cv id="PSI-MS" uri="http://psidev.cvs.sourceforge.net/viewvc/*checkout*/psidev/psi/psi-ms/mzML/controlledVocabulary/psi-ms.obo" version="3.30.0" fullName="PSI-MS"/>
+    <cv id="UNIMOD" uri="http://www.unimod.org/obo/unimod.obo" fullName="UNIMOD"/>
+    <cv id="UO" uri="http://obo.cvs.sourceforge.net/*checkout*/obo/obo/ontology/phenotype/unit.obo" fullName="UNIT-ONTOLOGY"/>
+</cvList>
+<AnalysisSoftwareList xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <AnalysisSoftware version="Beta (v10089)" name="MS-GF+" id="ID_software">
+        <SoftwareName>
+            <cvParam accession="MS:1002048" cvRef="PSI-MS" name="MS-GF+"/>
+        </SoftwareName>
+    </AnalysisSoftware>
+</AnalysisSoftwareList>
+<SequenceCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <DBSequence accession="XXX_gi|528968104|ref|XP_005212567.1|" searchDatabase_ref="SearchDB_1" length="815" id="DBSeq83632"/>
+    <DBSequence accession="XXX_gi|528968106|ref|XP_005212568.1|" searchDatabase_ref="SearchDB_1" length="811" id="DBSeq84448"/>
+    <DBSequence accession="XXX_gi|528968108|ref|XP_005212569.1|" searchDatabase_ref="SearchDB_1" length="766" id="DBSeq85260"/>
+    <DBSequence accession="XXX_gi|115497338|ref|NP_001069884.1|" searchDatabase_ref="SearchDB_1" length="626" id="DBSeq93486"/>
+    <DBSequence accession="gi|528993971|ref|XP_005219929.1|" searchDatabase_ref="SearchDB_1" length="768" id="DBSeq31093">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528993971|ref|XP_005219929.1| PREDICTED: lactoperoxidase isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528993973|ref|XP_005219930.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq31862">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528993973|ref|XP_005219930.1| PREDICTED: lactoperoxidase isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528993975|ref|XP_005219931.1|" searchDatabase_ref="SearchDB_1" length="685" id="DBSeq32575">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528993975|ref|XP_005219931.1| PREDICTED: lactoperoxidase isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|27806851|ref|NP_776358.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq47665">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|27806851|ref|NP_776358.1| lactoperoxidase precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|30466252|ref|NP_848667.1|" searchDatabase_ref="SearchDB_1" length="260" id="DBSeq46845">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|30466252|ref|NP_848667.1| carbonic anhydrase 2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|358414198|ref|XP_002700672.2|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq104353"/>
+    <DBSequence accession="XXX_gi|528966552|ref|XP_005211956.1|" searchDatabase_ref="SearchDB_1" length="1131" id="DBSeq107227"/>
+    <DBSequence accession="XXX_gi|528966554|ref|XP_005211957.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq108359"/>
+    <DBSequence accession="XXX_gi|297479727|ref|XP_002690982.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq109459"/>
+    <DBSequence accession="gi|32880221|ref|NP_872593.1|" searchDatabase_ref="SearchDB_1" length="558" id="DBSeq47106">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|32880221|ref|NP_872593.1| glutamate dehydrogenase 1, mitochondrial precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|30794280|ref|NP_851335.1|" searchDatabase_ref="SearchDB_1" length="607" id="DBSeq43937">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|30794280|ref|NP_851335.1| serum albumin precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528944676|ref|XP_005204734.1|" searchDatabase_ref="SearchDB_1" length="7610" id="DBSeq65480"/>
+    <DBSequence accession="XXX_gi|528944678|ref|XP_005204735.1|" searchDatabase_ref="SearchDB_1" length="5498" id="DBSeq73091"/>
+    <DBSequence accession="XXX_gi|219804516|ref|NP_001137332.1|" searchDatabase_ref="SearchDB_1" length="5422" id="DBSeq94489"/>
+    <DBSequence accession="XXX_gi|30794280|ref|NP_851335.1|" searchDatabase_ref="SearchDB_1" length="607" id="DBSeq99912"/>
+    <DBSequence accession="XXX_gi|528921178|ref|XP_592304.7|" searchDatabase_ref="SearchDB_1" length="1252" id="DBSeq60575"/>
+    <DBSequence accession="XXX_gi|528921180|ref|XP_005195747.1|" searchDatabase_ref="SearchDB_1" length="1197" id="DBSeq61828"/>
+    <DBSequence accession="XXX_gi|528995523|ref|XP_002695913.2|" searchDatabase_ref="SearchDB_1" length="1299" id="DBSeq89848"/>
+    <DBSequence accession="gi|528944676|ref|XP_005204734.1|" searchDatabase_ref="SearchDB_1" length="7610" id="DBSeq9505">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528944676|ref|XP_005204734.1| PREDICTED: microtubule-actin cross-linking factor 1 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528944678|ref|XP_005204735.1|" searchDatabase_ref="SearchDB_1" length="5498" id="DBSeq17116">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528944678|ref|XP_005204735.1| PREDICTED: microtubule-actin cross-linking factor 1 isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|219804516|ref|NP_001137332.1|" searchDatabase_ref="SearchDB_1" length="5422" id="DBSeq38514">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|219804516|ref|NP_001137332.1| microtubule-actin cross-linking factor 1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|139948503|ref|NP_001077142.1|" searchDatabase_ref="SearchDB_1" length="627" id="DBSeq92858"/>
+    <DBSequence accession="XXX_gi|358418103|ref|XP_600387.4|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq63026"/>
+    <DBSequence accession="XXX_gi|528923273|ref|XP_005196452.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq63881"/>
+    <DBSequence accession="XXX_gi|297488451|ref|XP_002696970.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq91148"/>
+    <DBSequence accession="XXX_gi|529000951|ref|XP_005222651.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq92003"/>
+    <DBSequence accession="gi|528928354|ref|XP_005193233.1|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq8761">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528928354|ref|XP_005193233.1| PREDICTED: fibrous sheath-interacting protein 2-like [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|32880221|ref|NP_872593.1|" searchDatabase_ref="SearchDB_1" length="558" id="DBSeq103081"/>
+    <DBSequence accession="gi|528921178|ref|XP_592304.7|" searchDatabase_ref="SearchDB_1" length="1252" id="DBSeq4600">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528921178|ref|XP_592304.7| PREDICTED: protein flightless-1 homolog isoformX1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528921180|ref|XP_005195747.1|" searchDatabase_ref="SearchDB_1" length="1197" id="DBSeq5853">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528921180|ref|XP_005195747.1| PREDICTED: protein flightless-1 homolog isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528995523|ref|XP_002695913.2|" searchDatabase_ref="SearchDB_1" length="1299" id="DBSeq33873">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528995523|ref|XP_002695913.2| PREDICTED: protein flightless-1 homolog [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528968106|ref|XP_005212568.1|" searchDatabase_ref="SearchDB_1" length="811" id="DBSeq28473">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968106|ref|XP_005212568.1| PREDICTED: exocyst complex component 6B isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528968104|ref|XP_005212567.1|" searchDatabase_ref="SearchDB_1" length="815" id="DBSeq27657">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968104|ref|XP_005212567.1| PREDICTED: exocyst complex component 6B isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528968108|ref|XP_005212569.1|" searchDatabase_ref="SearchDB_1" length="766" id="DBSeq29285">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968108|ref|XP_005212569.1| PREDICTED: exocyst complex component 6B isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|115497338|ref|NP_001069884.1|" searchDatabase_ref="SearchDB_1" length="626" id="DBSeq37511">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|115497338|ref|NP_001069884.1| exocyst complex component 6B [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528908802|ref|XP_005199340.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq248">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908802|ref|XP_005199340.1| PREDICTED: zinc finger protein 169 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528908804|ref|XP_005199341.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq865">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908804|ref|XP_005199341.1| PREDICTED: zinc finger protein 169 isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528908806|ref|XP_005199342.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq1482">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908806|ref|XP_005199342.1| PREDICTED: zinc finger protein 169 isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528908808|ref|XP_005199343.1|" searchDatabase_ref="SearchDB_1" length="615" id="DBSeq2099">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908808|ref|XP_005199343.1| PREDICTED: zinc finger protein 169 isoform X4 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528908810|ref|XP_005199344.1|" searchDatabase_ref="SearchDB_1" length="596" id="DBSeq2715">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908810|ref|XP_005199344.1| PREDICTED: zinc finger protein 169 isoform X5 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528908812|ref|XP_609847.5|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq3312">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528908812|ref|XP_609847.5| PREDICTED: zinc finger protein 169 isoform X6 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959647|ref|XP_005210511.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq24004">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959647|ref|XP_005210511.1| PREDICTED: zinc finger protein 169 isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959649|ref|XP_005210512.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq24621">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959649|ref|XP_005210512.1| PREDICTED: zinc finger protein 169 isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959651|ref|XP_005210513.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq25238">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959651|ref|XP_005210513.1| PREDICTED: zinc finger protein 169 isoform X4 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959653|ref|XP_005210514.1|" searchDatabase_ref="SearchDB_1" length="615" id="DBSeq25855">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959653|ref|XP_005210514.1| PREDICTED: zinc finger protein 169 isoform X5 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959655|ref|XP_005210515.1|" searchDatabase_ref="SearchDB_1" length="596" id="DBSeq26471">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959655|ref|XP_005210515.1| PREDICTED: zinc finger protein 169 isoform X6 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528959657|ref|XP_002689899.2|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq27068">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528959657|ref|XP_002689899.2| PREDICTED: zinc finger protein 169 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528928354|ref|XP_005193233.1|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq64736"/>
+    <DBSequence accession="XXX_gi|528961840|ref|XP_005211303.1|" searchDatabase_ref="SearchDB_1" length="719" id="DBSeq105830"/>
+    <DBSequence accession="XXX_gi|528961845|ref|XP_005211304.1|" searchDatabase_ref="SearchDB_1" length="676" id="DBSeq106550"/>
+    <DBSequence accession="XXX_gi|156523214|ref|NP_001096021.1|" searchDatabase_ref="SearchDB_1" length="676" id="DBSeq110897"/>
+    <DBSequence accession="gi|358414198|ref|XP_002700672.2|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq48378">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|358414198|ref|XP_002700672.2| PREDICTED: LOW QUALITY PROTEIN: solute carrier family 12 member 1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528966552|ref|XP_005211956.1|" searchDatabase_ref="SearchDB_1" length="1131" id="DBSeq51252">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528966552|ref|XP_005211956.1| PREDICTED: solute carrier family 12 member 1 isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528966554|ref|XP_005211957.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq52384">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528966554|ref|XP_005211957.1| PREDICTED: solute carrier family 12 member 1 isoform X3 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|297479727|ref|XP_002690982.1|" searchDatabase_ref="SearchDB_1" length="1099" id="DBSeq53484">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|297479727|ref|XP_002690982.1| PREDICTED: solute carrier family 12 member 1 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528908802|ref|XP_005199340.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq56223"/>
+    <DBSequence accession="XXX_gi|528908804|ref|XP_005199341.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq56840"/>
+    <DBSequence accession="XXX_gi|528908806|ref|XP_005199342.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq57457"/>
+    <DBSequence accession="XXX_gi|528908808|ref|XP_005199343.1|" searchDatabase_ref="SearchDB_1" length="615" id="DBSeq58074"/>
+    <DBSequence accession="XXX_gi|528908810|ref|XP_005199344.1|" searchDatabase_ref="SearchDB_1" length="596" id="DBSeq58690"/>
+    <DBSequence accession="XXX_gi|528908812|ref|XP_609847.5|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq59287"/>
+    <DBSequence accession="XXX_gi|528959647|ref|XP_005210511.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq79979"/>
+    <DBSequence accession="XXX_gi|528959649|ref|XP_005210512.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq80596"/>
+    <DBSequence accession="XXX_gi|528959651|ref|XP_005210513.1|" searchDatabase_ref="SearchDB_1" length="616" id="DBSeq81213"/>
+    <DBSequence accession="XXX_gi|528959653|ref|XP_005210514.1|" searchDatabase_ref="SearchDB_1" length="615" id="DBSeq81830"/>
+    <DBSequence accession="XXX_gi|528959655|ref|XP_005210515.1|" searchDatabase_ref="SearchDB_1" length="596" id="DBSeq82446"/>
+    <DBSequence accession="XXX_gi|528959657|ref|XP_002689899.2|" searchDatabase_ref="SearchDB_1" length="588" id="DBSeq83043"/>
+    <DBSequence accession="gi|528954392|ref|XP_005208526.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq23875">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528954392|ref|XP_005208526.1| PREDICTED: ubiquitin-60S ribosomal protein L40 isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|115496708|ref|NP_001069831.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq46340">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|115496708|ref|NP_001069831.1| ubiquitin-60S ribosomal protein L40 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528954392|ref|XP_005208526.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq79850"/>
+    <DBSequence accession="XXX_gi|115496708|ref|NP_001069831.1|" searchDatabase_ref="SearchDB_1" length="128" id="DBSeq102315"/>
+    <DBSequence accession="XXX_gi|28849955|ref|NP_788795.1|" searchDatabase_ref="SearchDB_1" length="375" id="DBSeq94113"/>
+    <DBSequence accession="XXX_gi|119924469|ref|XP_001252524.1|" searchDatabase_ref="SearchDB_1" length="376" id="DBSeq105453"/>
+    <DBSequence accession="gi|528968221|ref|XP_005212615.1|" searchDatabase_ref="SearchDB_1" length="156" id="DBSeq30052">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528968221|ref|XP_005212615.1| PREDICTED: ubiquitin-40S ribosomal protein S27a isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|27807503|ref|NP_777203.1|" searchDatabase_ref="SearchDB_1" length="156" id="DBSeq44851">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|27807503|ref|NP_777203.1| ubiquitin-40S ribosomal protein S27a [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|358418103|ref|XP_600387.4|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq7051">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|358418103|ref|XP_600387.4| PREDICTED: rab effector MyRIP isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|528923273|ref|XP_005196452.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq7906">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|528923273|ref|XP_005196452.1| PREDICTED: rab effector MyRIP isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|297488451|ref|XP_002696970.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq35173">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|297488451|ref|XP_002696970.1| PREDICTED: rab effector MyRIP isoform X1 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|529000951|ref|XP_005222651.1|" searchDatabase_ref="SearchDB_1" length="854" id="DBSeq36028">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|529000951|ref|XP_005222651.1| PREDICTED: rab effector MyRIP isoform X2 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|139948503|ref|NP_001077142.1|" searchDatabase_ref="SearchDB_1" length="627" id="DBSeq36883">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|139948503|ref|NP_001077142.1| uncharacterized protein LOC512219 [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|28849955|ref|NP_788795.1|" searchDatabase_ref="SearchDB_1" length="375" id="DBSeq38138">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|28849955|ref|NP_788795.1| pregnancy-associated glycoprotein 12 precursor [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="gi|119924469|ref|XP_001252524.1|" searchDatabase_ref="SearchDB_1" length="376" id="DBSeq49478">
+        <cvParam accession="MS:1001088" cvRef="PSI-MS" value="gi|119924469|ref|XP_001252524.1| PREDICTED: pregnancy-associated glycoprotein 2-like [Bos taurus]" name="protein description"/>
+    </DBSequence>
+    <DBSequence accession="XXX_gi|528993971|ref|XP_005219929.1|" searchDatabase_ref="SearchDB_1" length="768" id="DBSeq87068"/>
+    <DBSequence accession="XXX_gi|528993973|ref|XP_005219930.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq87837"/>
+    <DBSequence accession="XXX_gi|528993975|ref|XP_005219931.1|" searchDatabase_ref="SearchDB_1" length="685" id="DBSeq88550"/>
+    <DBSequence accession="XXX_gi|27806851|ref|NP_776358.1|" searchDatabase_ref="SearchDB_1" length="712" id="DBSeq103640"/>
+    <DBSequence accession="XXX_gi|528953234|ref|XP_005208080.1|" searchDatabase_ref="SearchDB_1" length="213" id="DBSeq78837"/>
+    <DBSequence accession="XXX_gi|528953236|ref|XP_005208081.1|" searchDatabase_ref="SearchDB_1" length="206" id="DBSeq79051"/>
+    <DBSequence accession="XXX_gi|528953238|ref|XP_005208082.1|" searchDatabase_ref="SearchDB_1" length="206" id="DBSeq79258"/>
+    <DBSequence accession="XXX_gi|528953240|ref|XP_005208083.1|" searchDatabase_ref="SearchDB_1" length="206" id="DBSeq79465"/>
+    <DBSequence accession="XXX_gi|528953246|ref|XP_005208086.1|" searchDatabase_ref="SearchDB_1" length="177" id="DBSeq79672"/>
+    <DBSequence accession="XXX_gi|30794348|ref|NP_851372.1|" searchDatabase_ref="SearchDB_1" length="214" id="DBSeq100983"/>
+    <Peptide id="Pep1">
+        <PeptideSequence>ISELFDKLDSMSVDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep2">
+        <PeptideSequence>PKNDPKLKTQGK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep3">
+        <PeptideSequence>EPISVSSQQMLK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep4">
+        <PeptideSequence>VWGFKVAGAQDEGK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep5">
+        <PeptideSequence>PTAEFQDR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep6">
+        <PeptideSequence>TVMENFVAFVDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep7">
+        <PeptideSequence>ESRCSRESRCSR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep8">
+        <PeptideSequence>ACCEELTAEYEKALR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep9">
+        <PeptideSequence>EVEDEGFLR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep10">
+        <PeptideSequence>MHQIYVQCAKL</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep11">
+        <PeptideSequence>KKYMRWMNHKKSR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep12">
+        <PeptideSequence>LAEAEKEGR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep13">
+        <PeptideSequence>AEMFEHLSEK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep14">
+        <PeptideSequence>SFNQEPQYR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep15">
+        <PeptideSequence>SKVNNYFWELSQTR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep16">
+        <PeptideSequence>PNTEPTHHFI</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep17">
+        <PeptideSequence>EGVAICKAGFR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep18">
+        <PeptideSequence>QLEDILVLAK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep19">
+        <PeptideSequence>AAQGALQPSL</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep20">
+        <PeptideSequence>VNPVTALTLLEKMK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep21">
+        <PeptideSequence>FEIWVELLKYLEEIRGK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep22">
+        <PeptideSequence>TIFDTEIESTSPK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep23">
+        <PeptideSequence>DTNIQICR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep24">
+        <PeptideSequence>QLEGRLQDLR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep25">
+        <PeptideSequence>RAFQECER</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep26">
+        <PeptideSequence>LECTNLYR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep27">
+        <PeptideSequence>LMLLSRDDSGSGSK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep28">
+        <PeptideSequence>ATEGTQLFNDYCEQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep29">
+        <PeptideSequence>IQNGALNCEEKLTLAK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep30">
+        <PeptideSequence>CVCDECGRGFGFK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep31">
+        <PeptideSequence>RMMESRQR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep32">
+        <PeptideSequence>RSDVEQLDQEIK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep33">
+        <PeptideSequence>WQEYQSRVD</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep34">
+        <PeptideSequence>RKFIIHRGKRKAAQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep35">
+        <PeptideSequence>VKDIVNLTDVNP</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep36">
+        <PeptideSequence>KELVDQRYDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep37">
+        <PeptideSequence>QNIDRCYPER</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep38">
+        <PeptideSequence>QLAQQTEQKGCR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep39">
+        <PeptideSequence>IFELEEH</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep40">
+        <PeptideSequence>VFEEMIEPYCLHESCK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep41">
+        <PeptideSequence>GLRFDWSLR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep42">
+        <PeptideSequence>VLETLGINKRKIVNQLSNSLTR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep43">
+        <PeptideSequence>DPDNSIELE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep44">
+        <PeptideSequence>LIIQLEQGDEPWR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep45">
+        <PeptideSequence>DPAPEGEIEMLDHAVK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep46">
+        <PeptideSequence>EVMEHR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep47">
+        <PeptideSequence>YNKCVDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep48">
+        <PeptideSequence>GFGRGCER</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep49">
+        <PeptideSequence>QLAQKYNCDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep50">
+        <PeptideSequence>DLGEEHF</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep51">
+        <PeptideSequence>DLPFLSNEYK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep52">
+        <PeptideSequence>DAHQKELVDQRYDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep53">
+        <PeptideSequence>QLQEELAEHQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep54">
+        <PeptideSequence>DAENTVRGR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep55">
+        <PeptideSequence>LNKDEVVTVDEAK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep56">
+        <PeptideSequence>LSETEMR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep57">
+        <PeptideSequence>DELVCEDNK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep58">
+        <PeptideSequence>CIMKDCNYKQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep59">
+        <PeptideSequence>ALDARDDACELLDGHCCEKHVK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep60">
+        <PeptideSequence>FGYEEQSLGFSQK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep61">
+        <PeptideSequence>AQQCVCCVWVK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep62">
+        <PeptideSequence>FFNPDDE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep63">
+        <PeptideSequence>HAAEEEIY</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep64">
+        <PeptideSequence>ESRELWNEF</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep65">
+        <PeptideSequence>MPPLIPAEVDK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep66">
+        <PeptideSequence>YYKVDE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep67">
+        <PeptideSequence>MMSASSYNE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep68">
+        <PeptideSequence>LMHDPSR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep69">
+        <PeptideSequence>YDGLVEQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep70">
+        <PeptideSequence>RCYPER</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep71">
+        <PeptideSequence>ARGCSEELS</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep72">
+        <PeptideSequence>AMFEELSSLK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep73">
+        <PeptideSequence>LIRRQRLRPR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep74">
+        <PeptideSequence>CDDQNKR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep75">
+        <PeptideSequence>EACFAVEGP</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep76">
+        <PeptideSequence>SKEVSNLEFSDR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep77">
+        <PeptideSequence>EKTGNTSSDQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep78">
+        <PeptideSequence>WGLDMERAGGQK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep79">
+        <PeptideSequence>EGQMVEEKYQK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep80">
+        <PeptideSequence>NTPDVMMSDTEK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep81">
+        <PeptideSequence>KECGAHSEDAVCTK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep82">
+        <PeptideSequence>PDIGDPNWISGDSE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep83">
+        <PeptideSequence>ELNPEEGQMVEEKYQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep84">
+        <PeptideSequence>NQDALTFFNSNQVS</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep85">
+        <PeptideSequence>DERDAAAESYHR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep86">
+        <PeptideSequence>QSFGLSQEEYGFDGA</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep87">
+        <PeptideSequence>NCNGSAACGLGYDFSR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep88">
+        <PeptideSequence>THKMYEAD</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep89">
+        <PeptideSequence>AEDEPEWPQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep90">
+        <PeptideSequence>TEGPTYETER</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep91">
+        <PeptideSequence>ASINPNNDSWDYALEE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep92">
+        <PeptideSequence>KQEESAEAGAPG</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep93">
+        <PeptideSequence>PFVCLECGR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep94">
+        <PeptideSequence>ENLEQAFE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep95">
+        <PeptideSequence>HYCGKCCL</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep96">
+        <PeptideSequence>WDFDEES</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep97">
+        <PeptideSequence>PPGAQGAEGGGSAEG</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep98">
+        <PeptideSequence>NQQPSLDQAHES</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep99">
+        <PeptideSequence>EGDYVSR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep100">
+        <PeptideSequence>EEDASSCQEQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep101">
+        <PeptideSequence>DENYYQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep102">
+        <PeptideSequence>ESEGKGCSMEAPQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep103">
+        <PeptideSequence>GEVAFCAEKDDAACCK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep104">
+        <PeptideSequence>MCNFHYQG</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep105">
+        <PeptideSequence>HGRDWF</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep106">
+        <PeptideSequence>EDLVPWIEDCK</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep107">
+        <PeptideSequence>MGHDRCR</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep108">
+        <PeptideSequence>EEEKEEEE</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep109">
+        <PeptideSequence>TGNTSSDQ</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep110">
+        <PeptideSequence>CGDCKFNVC</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep111">
+        <PeptideSequence>YNCDKMIC</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep112">
+        <PeptideSequence>PRALAVAVLCTLILL</PeptideSequence>
+    </Peptide>
+    <Peptide id="Pep113">
+        <PeptideSequence>CTNFSSCWSDGKM</PeptideSequence>
+    </Peptide>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="621" start="607" peptide_ref="Pep1" dBSequence_ref="DBSeq83632" id="PepEv_84238_1_607"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="617" start="603" peptide_ref="Pep1" dBSequence_ref="DBSeq84448" id="PepEv_85050_1_603"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="572" start="558" peptide_ref="Pep1" dBSequence_ref="DBSeq85260" id="PepEv_85817_1_558"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="432" start="418" peptide_ref="Pep1" dBSequence_ref="DBSeq93486" id="PepEv_93903_1_418"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="F" end="329" start="318" peptide_ref="Pep2" dBSequence_ref="DBSeq31093" id="PepEv_31410_2_318"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="F" end="273" start="262" peptide_ref="Pep2" dBSequence_ref="DBSeq31862" id="PepEv_32123_2_262"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="F" end="246" start="235" peptide_ref="Pep2" dBSequence_ref="DBSeq32575" id="PepEv_32809_2_235"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="F" end="273" start="262" peptide_ref="Pep2" dBSequence_ref="DBSeq47665" id="PepEv_47926_2_262"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="224" start="213" peptide_ref="Pep3" dBSequence_ref="DBSeq46845" id="PepEv_47057_3_213"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="933" start="920" peptide_ref="Pep4" dBSequence_ref="DBSeq104353" id="PepEv_105272_4_920"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="965" start="952" peptide_ref="Pep4" dBSequence_ref="DBSeq107227" id="PepEv_108178_4_952"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="933" start="920" peptide_ref="Pep4" dBSequence_ref="DBSeq108359" id="PepEv_109278_4_920"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="933" start="920" peptide_ref="Pep4" dBSequence_ref="DBSeq109459" id="PepEv_110378_4_920"/>
+    <PeptideEvidence isDecoy="false" post="I" pre="V" end="496" start="489" peptide_ref="Pep5" dBSequence_ref="DBSeq47106" id="PepEv_47594_5_489"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="K" end="580" start="569" peptide_ref="Pep6" dBSequence_ref="DBSeq43937" id="PepEv_44505_6_569"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="7523" start="7512" peptide_ref="Pep7" dBSequence_ref="DBSeq65480" id="PepEv_72991_7_7512"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="5411" start="5400" peptide_ref="Pep7" dBSequence_ref="DBSeq73091" id="PepEv_78490_7_5400"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="5411" start="5400" peptide_ref="Pep7" dBSequence_ref="DBSeq94489" id="PepEv_99888_7_5400"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="K" end="237" start="223" peptide_ref="Pep8" dBSequence_ref="DBSeq99912" id="PepEv_100134_8_223"/>
+    <PeptideEvidence isDecoy="true" post="A" pre="V" end="2003" start="1995" peptide_ref="Pep9" dBSequence_ref="DBSeq65480" id="PepEv_67474_9_1995"/>
+    <PeptideEvidence isDecoy="true" post="A" pre="V" end="1933" start="1925" peptide_ref="Pep9" dBSequence_ref="DBSeq73091" id="PepEv_75015_9_1925"/>
+    <PeptideEvidence isDecoy="true" post="A" pre="V" end="1933" start="1925" peptide_ref="Pep9" dBSequence_ref="DBSeq94489" id="PepEv_96413_9_1925"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="R" end="49" start="39" peptide_ref="Pep10" dBSequence_ref="DBSeq60575" id="PepEv_60613_10_39"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="R" end="49" start="39" peptide_ref="Pep10" dBSequence_ref="DBSeq61828" id="PepEv_61866_10_39"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="R" end="49" start="39" peptide_ref="Pep10" dBSequence_ref="DBSeq89848" id="PepEv_89886_10_39"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="R" end="7201" start="7189" peptide_ref="Pep11" dBSequence_ref="DBSeq9505" id="PepEv_16693_11_7189"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="R" end="5155" start="5143" peptide_ref="Pep11" dBSequence_ref="DBSeq17116" id="PepEv_22258_11_5143"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="R" end="5079" start="5067" peptide_ref="Pep11" dBSequence_ref="DBSeq38514" id="PepEv_43580_11_5067"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="T" end="2686" start="2678" peptide_ref="Pep12" dBSequence_ref="DBSeq9505" id="PepEv_12182_12_2678"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="Q" end="4275" start="4266" peptide_ref="Pep13" dBSequence_ref="DBSeq9505" id="PepEv_13770_13_4266"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="Q" end="2233" start="2224" peptide_ref="Pep13" dBSequence_ref="DBSeq17116" id="PepEv_19339_13_2224"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="Q" end="2157" start="2148" peptide_ref="Pep13" dBSequence_ref="DBSeq38514" id="PepEv_40661_13_2148"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="K" end="198" start="190" peptide_ref="Pep14" dBSequence_ref="DBSeq92858" id="PepEv_93047_14_190"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="741" start="728" peptide_ref="Pep15" dBSequence_ref="DBSeq63026" id="PepEv_63753_15_728"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="741" start="728" peptide_ref="Pep15" dBSequence_ref="DBSeq63881" id="PepEv_64608_15_728"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="741" start="728" peptide_ref="Pep15" dBSequence_ref="DBSeq91148" id="PepEv_91875_15_728"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="741" start="728" peptide_ref="Pep15" dBSequence_ref="DBSeq92003" id="PepEv_92730_15_728"/>
+    <PeptideEvidence isDecoy="false" post="H" pre="R" end="469" start="460" peptide_ref="Pep16" dBSequence_ref="DBSeq8761" id="PepEv_9220_16_460"/>
+    <PeptideEvidence isDecoy="true" post="H" pre="S" end="237" start="227" peptide_ref="Pep17" dBSequence_ref="DBSeq103081" id="PepEv_103307_17_227"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="5499" start="5490" peptide_ref="Pep18" dBSequence_ref="DBSeq9505" id="PepEv_14994_18_5490"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="3457" start="3448" peptide_ref="Pep18" dBSequence_ref="DBSeq17116" id="PepEv_20563_18_3448"/>
+    <PeptideEvidence isDecoy="false" post="Q" pre="K" end="3381" start="3372" peptide_ref="Pep18" dBSequence_ref="DBSeq38514" id="PepEv_41885_18_3372"/>
+    <PeptideEvidence isDecoy="false" post="Y" pre="K" end="1039" start="1030" peptide_ref="Pep19" dBSequence_ref="DBSeq4600" id="PepEv_5629_19_1030"/>
+    <PeptideEvidence isDecoy="false" post="Y" pre="K" end="984" start="975" peptide_ref="Pep19" dBSequence_ref="DBSeq5853" id="PepEv_6827_19_975"/>
+    <PeptideEvidence isDecoy="false" post="Y" pre="K" end="1086" start="1077" peptide_ref="Pep19" dBSequence_ref="DBSeq33873" id="PepEv_34949_19_1077"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="R" end="772" start="759" peptide_ref="Pep20" dBSequence_ref="DBSeq28473" id="PepEv_29231_20_759"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="G" end="7164" start="7148" peptide_ref="Pep21" dBSequence_ref="DBSeq65480" id="PepEv_72627_21_7148"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="G" end="5052" start="5036" peptide_ref="Pep21" dBSequence_ref="DBSeq73091" id="PepEv_78126_21_5036"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="G" end="5052" start="5036" peptide_ref="Pep21" dBSequence_ref="DBSeq94489" id="PepEv_99524_21_5036"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="Y" end="264" start="252" peptide_ref="Pep22" dBSequence_ref="DBSeq27657" id="PepEv_27908_22_252"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="Y" end="264" start="252" peptide_ref="Pep22" dBSequence_ref="DBSeq28473" id="PepEv_28724_22_252"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="Y" end="264" start="252" peptide_ref="Pep22" dBSequence_ref="DBSeq29285" id="PepEv_29536_22_252"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="Y" end="264" start="252" peptide_ref="Pep22" dBSequence_ref="DBSeq37511" id="PepEv_37762_22_252"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="S" end="201" start="194" peptide_ref="Pep23" dBSequence_ref="DBSeq60575" id="PepEv_60768_23_194"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="S" end="201" start="194" peptide_ref="Pep23" dBSequence_ref="DBSeq61828" id="PepEv_62021_23_194"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="S" end="201" start="194" peptide_ref="Pep23" dBSequence_ref="DBSeq89848" id="PepEv_90041_23_194"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="E" end="3551" start="3542" peptide_ref="Pep24" dBSequence_ref="DBSeq9505" id="PepEv_13046_24_3542"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="S" end="112" start="105" peptide_ref="Pep25" dBSequence_ref="DBSeq83632" id="PepEv_83736_25_105"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="S" end="108" start="101" peptide_ref="Pep25" dBSequence_ref="DBSeq84448" id="PepEv_84548_25_101"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="S" end="63" start="56" peptide_ref="Pep25" dBSequence_ref="DBSeq85260" id="PepEv_85315_25_56"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="604" start="597" peptide_ref="Pep26" dBSequence_ref="DBSeq9505" id="PepEv_10101_26_597"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="604" start="597" peptide_ref="Pep26" dBSequence_ref="DBSeq17116" id="PepEv_17712_26_597"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="528" start="521" peptide_ref="Pep26" dBSequence_ref="DBSeq38514" id="PepEv_39034_26_521"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="6563" start="6550" peptide_ref="Pep27" dBSequence_ref="DBSeq9505" id="PepEv_16054_27_6550"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="4521" start="4508" peptide_ref="Pep27" dBSequence_ref="DBSeq17116" id="PepEv_21623_27_4508"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="4445" start="4432" peptide_ref="Pep27" dBSequence_ref="DBSeq38514" id="PepEv_42945_27_4432"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="1033" start="1020" peptide_ref="Pep28" dBSequence_ref="DBSeq104353" id="PepEv_105372_28_1020"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="1065" start="1052" peptide_ref="Pep28" dBSequence_ref="DBSeq107227" id="PepEv_108278_28_1052"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="1033" start="1020" peptide_ref="Pep28" dBSequence_ref="DBSeq108359" id="PepEv_109378_28_1020"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="1033" start="1020" peptide_ref="Pep28" dBSequence_ref="DBSeq109459" id="PepEv_110478_28_1020"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="527" start="512" peptide_ref="Pep29" dBSequence_ref="DBSeq9505" id="PepEv_10016_29_512"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="527" start="512" peptide_ref="Pep29" dBSequence_ref="DBSeq17116" id="PepEv_17627_29_512"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="451" start="436" peptide_ref="Pep29" dBSequence_ref="DBSeq38514" id="PepEv_38949_29_436"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="566" start="554" peptide_ref="Pep30" dBSequence_ref="DBSeq248" id="PepEv_801_30_554"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="566" start="554" peptide_ref="Pep30" dBSequence_ref="DBSeq865" id="PepEv_1418_30_554"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="566" start="554" peptide_ref="Pep30" dBSequence_ref="DBSeq1482" id="PepEv_2035_30_554"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="565" start="553" peptide_ref="Pep30" dBSequence_ref="DBSeq2099" id="PepEv_2651_30_553"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="546" start="534" peptide_ref="Pep30" dBSequence_ref="DBSeq2715" id="PepEv_3248_30_534"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="538" start="526" peptide_ref="Pep30" dBSequence_ref="DBSeq3312" id="PepEv_3837_30_526"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="566" start="554" peptide_ref="Pep30" dBSequence_ref="DBSeq24004" id="PepEv_24557_30_554"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="566" start="554" peptide_ref="Pep30" dBSequence_ref="DBSeq24621" id="PepEv_25174_30_554"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="566" start="554" peptide_ref="Pep30" dBSequence_ref="DBSeq25238" id="PepEv_25791_30_554"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="565" start="553" peptide_ref="Pep30" dBSequence_ref="DBSeq25855" id="PepEv_26407_30_553"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="546" start="534" peptide_ref="Pep30" dBSequence_ref="DBSeq26471" id="PepEv_27004_30_534"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="P" end="538" start="526" peptide_ref="Pep30" dBSequence_ref="DBSeq27068" id="PepEv_27593_30_526"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="40" start="33" peptide_ref="Pep31" dBSequence_ref="DBSeq64736" id="PepEv_64768_31_33"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="I" end="4789" start="4778" peptide_ref="Pep32" dBSequence_ref="DBSeq9505" id="PepEv_14282_32_4778"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="I" end="2747" start="2736" peptide_ref="Pep32" dBSequence_ref="DBSeq17116" id="PepEv_19851_32_2736"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="I" end="2671" start="2660" peptide_ref="Pep32" dBSequence_ref="DBSeq38514" id="PepEv_41173_32_2660"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="R" end="400" start="392" peptide_ref="Pep33" dBSequence_ref="DBSeq9505" id="PepEv_9896_33_392"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="R" end="400" start="392" peptide_ref="Pep33" dBSequence_ref="DBSeq17116" id="PepEv_17507_33_392"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="R" end="324" start="316" peptide_ref="Pep33" dBSequence_ref="DBSeq38514" id="PepEv_38829_33_316"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="K" end="1032" start="1019" peptide_ref="Pep34" dBSequence_ref="DBSeq4600" id="PepEv_5618_34_1019"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="K" end="977" start="964" peptide_ref="Pep34" dBSequence_ref="DBSeq5853" id="PepEv_6816_34_964"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="K" end="1079" start="1066" peptide_ref="Pep34" dBSequence_ref="DBSeq33873" id="PepEv_34938_34_1066"/>
+    <PeptideEvidence isDecoy="true" post="N" pre="K" end="5435" start="5424" peptide_ref="Pep35" dBSequence_ref="DBSeq65480" id="PepEv_70903_35_5424"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="Q" end="1977" start="1968" peptide_ref="Pep36" dBSequence_ref="DBSeq65480" id="PepEv_67447_36_1968"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="Q" end="1907" start="1898" peptide_ref="Pep36" dBSequence_ref="DBSeq73091" id="PepEv_74988_36_1898"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="Q" end="1907" start="1898" peptide_ref="Pep36" dBSequence_ref="DBSeq94489" id="PepEv_96386_36_1898"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="L" end="20" start="11" peptide_ref="Pep37" dBSequence_ref="DBSeq105830" id="PepEv_105840_37_11"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="L" end="20" start="11" peptide_ref="Pep37" dBSequence_ref="DBSeq106550" id="PepEv_106560_37_11"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="L" end="20" start="11" peptide_ref="Pep37" dBSequence_ref="DBSeq110897" id="PepEv_110907_37_11"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="S" end="1624" start="1613" peptide_ref="Pep38" dBSequence_ref="DBSeq9505" id="PepEv_11117_38_1613"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="1401" start="1395" peptide_ref="Pep39" dBSequence_ref="DBSeq65480" id="PepEv_66874_39_1395"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="1331" start="1325" peptide_ref="Pep39" dBSequence_ref="DBSeq73091" id="PepEv_74415_39_1325"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="1331" start="1325" peptide_ref="Pep39" dBSequence_ref="DBSeq94489" id="PepEv_95813_39_1325"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="1005" start="990" peptide_ref="Pep40" dBSequence_ref="DBSeq48378" id="PepEv_49367_40_990"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="1037" start="1022" peptide_ref="Pep40" dBSequence_ref="DBSeq51252" id="PepEv_52273_40_1022"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="1005" start="990" peptide_ref="Pep40" dBSequence_ref="DBSeq52384" id="PepEv_53373_40_990"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="K" end="1005" start="990" peptide_ref="Pep40" dBSequence_ref="DBSeq53484" id="PepEv_54473_40_990"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="P" end="536" start="528" peptide_ref="Pep41" dBSequence_ref="DBSeq105830" id="PepEv_106357_41_528"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="P" end="536" start="528" peptide_ref="Pep41" dBSequence_ref="DBSeq106550" id="PepEv_107077_41_528"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="P" end="536" start="528" peptide_ref="Pep41" dBSequence_ref="DBSeq110897" id="PepEv_111424_41_528"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="Q" end="280" start="259" peptide_ref="Pep42" dBSequence_ref="DBSeq83632" id="PepEv_83890_42_259"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="Q" end="276" start="255" peptide_ref="Pep42" dBSequence_ref="DBSeq84448" id="PepEv_84702_42_255"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="Q" end="231" start="210" peptide_ref="Pep42" dBSequence_ref="DBSeq85260" id="PepEv_85469_42_210"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="Q" end="91" start="70" peptide_ref="Pep42" dBSequence_ref="DBSeq93486" id="PepEv_93555_42_70"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="882" start="874" peptide_ref="Pep43" dBSequence_ref="DBSeq65480" id="PepEv_66353_43_874"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="812" start="804" peptide_ref="Pep43" dBSequence_ref="DBSeq73091" id="PepEv_73894_43_804"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="812" start="804" peptide_ref="Pep43" dBSequence_ref="DBSeq94489" id="PepEv_95292_43_804"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq248" id="PepEv_324_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq865" id="PepEv_941_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq1482" id="PepEv_1558_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq2099" id="PepEv_2175_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="69" start="57" peptide_ref="Pep44" dBSequence_ref="DBSeq2715" id="PepEv_2771_44_57"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="61" start="49" peptide_ref="Pep44" dBSequence_ref="DBSeq3312" id="PepEv_3360_44_49"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq24004" id="PepEv_24080_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq24621" id="PepEv_24697_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq25238" id="PepEv_25314_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="89" start="77" peptide_ref="Pep44" dBSequence_ref="DBSeq25855" id="PepEv_25931_44_77"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="69" start="57" peptide_ref="Pep44" dBSequence_ref="DBSeq26471" id="PepEv_26527_44_57"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="61" start="49" peptide_ref="Pep44" dBSequence_ref="DBSeq27068" id="PepEv_27116_44_49"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="R" end="3505" start="3490" peptide_ref="Pep45" dBSequence_ref="DBSeq65480" id="PepEv_68969_45_3490"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="R" end="3435" start="3420" peptide_ref="Pep45" dBSequence_ref="DBSeq73091" id="PepEv_76510_45_3420"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="R" end="3435" start="3420" peptide_ref="Pep45" dBSequence_ref="DBSeq94489" id="PepEv_97908_45_3420"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="5768" start="5763" peptide_ref="Pep46" dBSequence_ref="DBSeq9505" id="PepEv_15267_46_5763"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3726" start="3721" peptide_ref="Pep46" dBSequence_ref="DBSeq17116" id="PepEv_20836_46_3721"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="K" end="3650" start="3645" peptide_ref="Pep46" dBSequence_ref="DBSeq38514" id="PepEv_42158_46_3645"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="Q" end="272" start="266" peptide_ref="Pep47" dBSequence_ref="DBSeq99912" id="PepEv_100177_47_266"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq56223" id="PepEv_56555_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq56840" id="PepEv_57172_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq57457" id="PepEv_57789_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq58074" id="PepEv_58406_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq58690" id="PepEv_59022_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq59287" id="PepEv_59619_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq79979" id="PepEv_80311_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq80596" id="PepEv_80928_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq81213" id="PepEv_81545_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq81830" id="PepEv_82162_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq82446" id="PepEv_82778_48_333"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="R" end="340" start="333" peptide_ref="Pep48" dBSequence_ref="DBSeq83043" id="PepEv_83375_48_333"/>
+    <PeptideEvidence isDecoy="false" post="M" pre="R" end="93" start="84" peptide_ref="Pep49" dBSequence_ref="DBSeq23875" id="PepEv_23958_49_84"/>
+    <PeptideEvidence isDecoy="false" post="M" pre="R" end="93" start="84" peptide_ref="Pep49" dBSequence_ref="DBSeq46340" id="PepEv_46423_49_84"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="43" start="37" peptide_ref="Pep50" dBSequence_ref="DBSeq43937" id="PepEv_43973_50_37"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="3230" start="3221" peptide_ref="Pep51" dBSequence_ref="DBSeq9505" id="PepEv_12725_51_3221"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="H" end="1977" start="1964" peptide_ref="Pep52" dBSequence_ref="DBSeq65480" id="PepEv_67443_52_1964"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="H" end="1907" start="1894" peptide_ref="Pep52" dBSequence_ref="DBSeq73091" id="PepEv_74984_52_1894"/>
+    <PeptideEvidence isDecoy="true" post="V" pre="H" end="1907" start="1894" peptide_ref="Pep52" dBSequence_ref="DBSeq94489" id="PepEv_96382_52_1894"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="4098" start="4089" peptide_ref="Pep53" dBSequence_ref="DBSeq9505" id="PepEv_13593_53_4089"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="2056" start="2047" peptide_ref="Pep53" dBSequence_ref="DBSeq17116" id="PepEv_19162_53_2047"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="K" end="1980" start="1971" peptide_ref="Pep53" dBSequence_ref="DBSeq38514" id="PepEv_40484_53_1971"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="2541" start="2533" peptide_ref="Pep54" dBSequence_ref="DBSeq9505" id="PepEv_12037_54_2533"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="L" end="5387" start="5375" peptide_ref="Pep55" dBSequence_ref="DBSeq65480" id="PepEv_70854_55_5375"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="Q" end="459" start="453" peptide_ref="Pep56" dBSequence_ref="DBSeq8761" id="PepEv_9213_56_453"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="N" end="6645" start="6637" peptide_ref="Pep57" dBSequence_ref="DBSeq65480" id="PepEv_72116_57_6637"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="N" end="4535" start="4527" peptide_ref="Pep57" dBSequence_ref="DBSeq73091" id="PepEv_77617_57_4527"/>
+    <PeptideEvidence isDecoy="true" post="C" pre="N" end="4535" start="4527" peptide_ref="Pep57" dBSequence_ref="DBSeq94489" id="PepEv_99015_57_4527"/>
+    <PeptideEvidence isDecoy="true" post="A" pre="R" end="42" start="33" peptide_ref="Pep58" dBSequence_ref="DBSeq79850" id="PepEv_79882_58_33"/>
+    <PeptideEvidence isDecoy="true" post="A" pre="R" end="42" start="33" peptide_ref="Pep58" dBSequence_ref="DBSeq102315" id="PepEv_102347_58_33"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="345" start="324" peptide_ref="Pep59" dBSequence_ref="DBSeq99912" id="PepEv_100235_59_324"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="D" end="224" start="212" peptide_ref="Pep60" dBSequence_ref="DBSeq94113" id="PepEv_94324_60_212"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="D" end="225" start="213" peptide_ref="Pep60" dBSequence_ref="DBSeq105453" id="PepEv_105665_60_213"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="755" start="745" peptide_ref="Pep61" dBSequence_ref="DBSeq63026" id="PepEv_63770_61_745"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="755" start="745" peptide_ref="Pep61" dBSequence_ref="DBSeq63881" id="PepEv_64625_61_745"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="755" start="745" peptide_ref="Pep61" dBSequence_ref="DBSeq91148" id="PepEv_91892_61_745"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="R" end="755" start="745" peptide_ref="Pep61" dBSequence_ref="DBSeq92003" id="PepEv_92747_61_745"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="K" end="498" start="492" peptide_ref="Pep62" dBSequence_ref="DBSeq103081" id="PepEv_103572_62_492"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="611" start="604" peptide_ref="Pep63" dBSequence_ref="DBSeq27657" id="PepEv_28260_63_604"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="611" start="604" peptide_ref="Pep63" dBSequence_ref="DBSeq28473" id="PepEv_29076_63_604"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="611" start="604" peptide_ref="Pep63" dBSequence_ref="DBSeq29285" id="PepEv_29888_63_604"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="3674" start="3666" peptide_ref="Pep64" dBSequence_ref="DBSeq65480" id="PepEv_69145_64_3666"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="3604" start="3596" peptide_ref="Pep64" dBSequence_ref="DBSeq73091" id="PepEv_76686_64_3596"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="3604" start="3596" peptide_ref="Pep64" dBSequence_ref="DBSeq94489" id="PepEv_98084_64_3596"/>
+    <PeptideEvidence isDecoy="false" post="I" pre="R" end="6078" start="6068" peptide_ref="Pep65" dBSequence_ref="DBSeq9505" id="PepEv_15572_65_6068"/>
+    <PeptideEvidence isDecoy="false" post="I" pre="R" end="4036" start="4026" peptide_ref="Pep65" dBSequence_ref="DBSeq17116" id="PepEv_21141_65_4026"/>
+    <PeptideEvidence isDecoy="false" post="I" pre="R" end="3960" start="3950" peptide_ref="Pep65" dBSequence_ref="DBSeq38514" id="PepEv_42463_65_3950"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="110" start="105" peptide_ref="Pep66" dBSequence_ref="DBSeq30052" id="PepEv_30156_66_105"/>
+    <PeptideEvidence isDecoy="false" post="N" pre="K" end="110" start="105" peptide_ref="Pep66" dBSequence_ref="DBSeq44851" id="PepEv_44955_66_105"/>
+    <PeptideEvidence isDecoy="false" post="D" pre="R" end="480" start="472" peptide_ref="Pep67" dBSequence_ref="DBSeq8761" id="PepEv_9232_67_472"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="6672" start="6666" peptide_ref="Pep68" dBSequence_ref="DBSeq65480" id="PepEv_72145_68_6666"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="4562" start="4556" peptide_ref="Pep68" dBSequence_ref="DBSeq73091" id="PepEv_77646_68_4556"/>
+    <PeptideEvidence isDecoy="true" post="P" pre="K" end="4562" start="4556" peptide_ref="Pep68" dBSequence_ref="DBSeq94489" id="PepEv_99044_68_4556"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="6259" start="6253" peptide_ref="Pep69" dBSequence_ref="DBSeq65480" id="PepEv_71732_69_6253"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="4149" start="4143" peptide_ref="Pep69" dBSequence_ref="DBSeq73091" id="PepEv_77233_69_4143"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="4149" start="4143" peptide_ref="Pep69" dBSequence_ref="DBSeq94489" id="PepEv_98631_69_4143"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="D" end="20" start="15" peptide_ref="Pep70" dBSequence_ref="DBSeq105830" id="PepEv_105844_70_15"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="D" end="20" start="15" peptide_ref="Pep70" dBSequence_ref="DBSeq106550" id="PepEv_106564_70_15"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="D" end="20" start="15" peptide_ref="Pep70" dBSequence_ref="DBSeq110897" id="PepEv_110911_70_15"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="533" start="525" peptide_ref="Pep71" dBSequence_ref="DBSeq7051" id="PepEv_7575_71_525"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="533" start="525" peptide_ref="Pep71" dBSequence_ref="DBSeq7906" id="PepEv_8430_71_525"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="533" start="525" peptide_ref="Pep71" dBSequence_ref="DBSeq35173" id="PepEv_35697_71_525"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="533" start="525" peptide_ref="Pep71" dBSequence_ref="DBSeq36028" id="PepEv_36552_71_525"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="A" end="954" start="945" peptide_ref="Pep72" dBSequence_ref="DBSeq60575" id="PepEv_61519_72_945"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="A" end="953" start="944" peptide_ref="Pep72" dBSequence_ref="DBSeq61828" id="PepEv_62771_72_944"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="A" end="954" start="945" peptide_ref="Pep72" dBSequence_ref="DBSeq89848" id="PepEv_90792_72_945"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="K" end="22" start="13" peptide_ref="Pep73" dBSequence_ref="DBSeq36883" id="PepEv_36895_73_13"/>
+    <PeptideEvidence isDecoy="false" post="S" pre="E" end="2937" start="2931" peptide_ref="Pep74" dBSequence_ref="DBSeq9505" id="PepEv_12435_74_2931"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="596" start="588" peptide_ref="Pep75" dBSequence_ref="DBSeq43937" id="PepEv_44524_75_588"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="G" end="3265" start="3254" peptide_ref="Pep76" dBSequence_ref="DBSeq9505" id="PepEv_12758_76_3254"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="29" start="20" peptide_ref="Pep77" dBSequence_ref="DBSeq63026" id="PepEv_63045_77_20"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="29" start="20" peptide_ref="Pep77" dBSequence_ref="DBSeq63881" id="PepEv_63900_77_20"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="29" start="20" peptide_ref="Pep77" dBSequence_ref="DBSeq91148" id="PepEv_91167_77_20"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="R" end="29" start="20" peptide_ref="Pep77" dBSequence_ref="DBSeq92003" id="PepEv_92022_77_20"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="419" start="408" peptide_ref="Pep78" dBSequence_ref="DBSeq105830" id="PepEv_106237_78_408"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="419" start="408" peptide_ref="Pep78" dBSequence_ref="DBSeq106550" id="PepEv_106957_78_408"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="K" end="419" start="408" peptide_ref="Pep78" dBSequence_ref="DBSeq110897" id="PepEv_111304_78_408"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="E" end="6016" start="6006" peptide_ref="Pep79" dBSequence_ref="DBSeq9505" id="PepEv_15510_79_6006"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="E" end="3974" start="3964" peptide_ref="Pep79" dBSequence_ref="DBSeq17116" id="PepEv_21079_79_3964"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="E" end="3898" start="3888" peptide_ref="Pep79" dBSequence_ref="DBSeq38514" id="PepEv_42401_79_3888"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="D" end="812" start="801" peptide_ref="Pep80" dBSequence_ref="DBSeq104353" id="PepEv_105153_80_801"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="D" end="812" start="801" peptide_ref="Pep80" dBSequence_ref="DBSeq107227" id="PepEv_108027_80_801"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="D" end="812" start="801" peptide_ref="Pep80" dBSequence_ref="DBSeq108359" id="PepEv_109159_80_801"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="D" end="812" start="801" peptide_ref="Pep80" dBSequence_ref="DBSeq109459" id="PepEv_110259_80_801"/>
+    <PeptideEvidence isDecoy="true" post="A" pre="S" end="533" start="520" peptide_ref="Pep81" dBSequence_ref="DBSeq99912" id="PepEv_100431_81_520"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="K" end="227" start="214" peptide_ref="Pep82" dBSequence_ref="DBSeq103081" id="PepEv_103294_82_214"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="6015" start="6001" peptide_ref="Pep83" dBSequence_ref="DBSeq9505" id="PepEv_15505_83_6001"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="3973" start="3959" peptide_ref="Pep83" dBSequence_ref="DBSeq17116" id="PepEv_21074_83_3959"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="K" end="3897" start="3883" peptide_ref="Pep83" dBSequence_ref="DBSeq38514" id="PepEv_42396_83_3883"/>
+    <PeptideEvidence isDecoy="false" post="E" pre="R" end="3148" start="3135" peptide_ref="Pep84" dBSequence_ref="DBSeq9505" id="PepEv_12639_84_3135"/>
+    <PeptideEvidence isDecoy="true" post="R" pre="D" end="508" start="497" peptide_ref="Pep85" dBSequence_ref="DBSeq103081" id="PepEv_103577_85_497"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="K" end="167" start="153" peptide_ref="Pep86" dBSequence_ref="DBSeq38138" id="PepEv_38290_86_153"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="K" end="167" start="153" peptide_ref="Pep86" dBSequence_ref="DBSeq49478" id="PepEv_49630_86_153"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="M" end="469" start="454" peptide_ref="Pep87" dBSequence_ref="DBSeq48378" id="PepEv_48831_87_454"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="M" end="501" start="486" peptide_ref="Pep87" dBSequence_ref="DBSeq51252" id="PepEv_51737_87_486"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="M" end="469" start="454" peptide_ref="Pep87" dBSequence_ref="DBSeq52384" id="PepEv_52837_87_454"/>
+    <PeptideEvidence isDecoy="false" post="C" pre="M" end="469" start="454" peptide_ref="Pep87" dBSequence_ref="DBSeq53484" id="PepEv_53937_87_454"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="113" start="106" peptide_ref="Pep88" dBSequence_ref="DBSeq60575" id="PepEv_60680_88_106"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="113" start="106" peptide_ref="Pep88" dBSequence_ref="DBSeq61828" id="PepEv_61933_88_106"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="113" start="106" peptide_ref="Pep88" dBSequence_ref="DBSeq89848" id="PepEv_89953_88_106"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="R" end="264" start="256" peptide_ref="Pep89" dBSequence_ref="DBSeq7051" id="PepEv_7306_89_256"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="R" end="264" start="256" peptide_ref="Pep89" dBSequence_ref="DBSeq7906" id="PepEv_8161_89_256"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="R" end="264" start="256" peptide_ref="Pep89" dBSequence_ref="DBSeq35173" id="PepEv_35428_89_256"/>
+    <PeptideEvidence isDecoy="false" post="P" pre="R" end="264" start="256" peptide_ref="Pep89" dBSequence_ref="DBSeq36028" id="PepEv_36283_89_256"/>
+    <PeptideEvidence isDecoy="true" post="T" pre="G" end="5347" start="5338" peptide_ref="Pep90" dBSequence_ref="DBSeq65480" id="PepEv_70817_90_5338"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="6833" start="6818" peptide_ref="Pep91" dBSequence_ref="DBSeq65480" id="PepEv_72297_91_6818"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4721" start="4706" peptide_ref="Pep91" dBSequence_ref="DBSeq73091" id="PepEv_77796_91_4706"/>
+    <PeptideEvidence isDecoy="true" post="E" pre="K" end="4721" start="4706" peptide_ref="Pep91" dBSequence_ref="DBSeq94489" id="PepEv_99194_91_4706"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="454" start="443" peptide_ref="Pep92" dBSequence_ref="DBSeq4600" id="PepEv_5042_92_443"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="399" start="388" peptide_ref="Pep92" dBSequence_ref="DBSeq5853" id="PepEv_6240_92_388"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="501" start="490" peptide_ref="Pep92" dBSequence_ref="DBSeq33873" id="PepEv_34362_92_490"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="393" start="385" peptide_ref="Pep93" dBSequence_ref="DBSeq248" id="PepEv_632_93_385"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="393" start="385" peptide_ref="Pep93" dBSequence_ref="DBSeq865" id="PepEv_1249_93_385"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="393" start="385" peptide_ref="Pep93" dBSequence_ref="DBSeq1482" id="PepEv_1866_93_385"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="392" start="384" peptide_ref="Pep93" dBSequence_ref="DBSeq2099" id="PepEv_2482_93_384"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="373" start="365" peptide_ref="Pep93" dBSequence_ref="DBSeq2715" id="PepEv_3079_93_365"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="365" start="357" peptide_ref="Pep93" dBSequence_ref="DBSeq3312" id="PepEv_3668_93_357"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="393" start="385" peptide_ref="Pep93" dBSequence_ref="DBSeq24004" id="PepEv_24388_93_385"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="393" start="385" peptide_ref="Pep93" dBSequence_ref="DBSeq24621" id="PepEv_25005_93_385"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="393" start="385" peptide_ref="Pep93" dBSequence_ref="DBSeq25238" id="PepEv_25622_93_385"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="392" start="384" peptide_ref="Pep93" dBSequence_ref="DBSeq25855" id="PepEv_26238_93_384"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="373" start="365" peptide_ref="Pep93" dBSequence_ref="DBSeq26471" id="PepEv_26835_93_365"/>
+    <PeptideEvidence isDecoy="false" post="G" pre="R" end="365" start="357" peptide_ref="Pep93" dBSequence_ref="DBSeq27068" id="PepEv_27424_93_357"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="R" end="336" start="329" peptide_ref="Pep94" dBSequence_ref="DBSeq9505" id="PepEv_9833_94_329"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="R" end="336" start="329" peptide_ref="Pep94" dBSequence_ref="DBSeq17116" id="PepEv_17444_94_329"/>
+    <PeptideEvidence isDecoy="false" post="V" pre="R" end="260" start="253" peptide_ref="Pep94" dBSequence_ref="DBSeq38514" id="PepEv_38766_94_253"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="146" start="139" peptide_ref="Pep95" dBSequence_ref="DBSeq30052" id="PepEv_30190_95_139"/>
+    <PeptideEvidence isDecoy="false" post="T" pre="R" end="146" start="139" peptide_ref="Pep95" dBSequence_ref="DBSeq44851" id="PepEv_44989_95_139"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="460" start="454" peptide_ref="Pep96" dBSequence_ref="DBSeq63026" id="PepEv_63479_96_454"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="460" start="454" peptide_ref="Pep96" dBSequence_ref="DBSeq63881" id="PepEv_64334_96_454"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="460" start="454" peptide_ref="Pep96" dBSequence_ref="DBSeq91148" id="PepEv_91601_96_454"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="R" end="460" start="454" peptide_ref="Pep96" dBSequence_ref="DBSeq92003" id="PepEv_92456_96_454"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="K" end="386" start="372" peptide_ref="Pep97" dBSequence_ref="DBSeq105830" id="PepEv_106201_97_372"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="K" end="386" start="372" peptide_ref="Pep97" dBSequence_ref="DBSeq106550" id="PepEv_106921_97_372"/>
+    <PeptideEvidence isDecoy="true" post="G" pre="K" end="386" start="372" peptide_ref="Pep97" dBSequence_ref="DBSeq110897" id="PepEv_111268_97_372"/>
+    <PeptideEvidence isDecoy="true" post="I" pre="R" end="4003" start="3992" peptide_ref="Pep98" dBSequence_ref="DBSeq65480" id="PepEv_69471_98_3992"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="E" end="778" start="772" peptide_ref="Pep99" dBSequence_ref="DBSeq83632" id="PepEv_84403_99_772"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="E" end="774" start="768" peptide_ref="Pep99" dBSequence_ref="DBSeq84448" id="PepEv_85215_99_768"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="E" end="729" start="723" peptide_ref="Pep99" dBSequence_ref="DBSeq85260" id="PepEv_85982_99_723"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="E" end="589" start="583" peptide_ref="Pep99" dBSequence_ref="DBSeq93486" id="PepEv_94068_99_583"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="4371" start="4362" peptide_ref="Pep100" dBSequence_ref="DBSeq9505" id="PepEv_13866_100_4362"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="2329" start="2320" peptide_ref="Pep100" dBSequence_ref="DBSeq17116" id="PepEv_19435_100_2320"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="2253" start="2244" peptide_ref="Pep100" dBSequence_ref="DBSeq38514" id="PepEv_40757_100_2244"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="577" start="572" peptide_ref="Pep101" dBSequence_ref="DBSeq9505" id="PepEv_10076_101_572"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="577" start="572" peptide_ref="Pep101" dBSequence_ref="DBSeq17116" id="PepEv_17687_101_572"/>
+    <PeptideEvidence isDecoy="false" post="L" pre="R" end="501" start="496" peptide_ref="Pep101" dBSequence_ref="DBSeq38514" id="PepEv_39009_101_496"/>
+    <PeptideEvidence isDecoy="true" post="S" pre="K" end="4729" start="4717" peptide_ref="Pep102" dBSequence_ref="DBSeq65480" id="PepEv_70196_102_4717"/>
+    <PeptideEvidence isDecoy="true" post="D" pre="P" end="28" start="13" peptide_ref="Pep103" dBSequence_ref="DBSeq99912" id="PepEv_99924_103_13"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="74" start="67" peptide_ref="Pep104" dBSequence_ref="DBSeq27657" id="PepEv_27723_104_67"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="74" start="67" peptide_ref="Pep104" dBSequence_ref="DBSeq28473" id="PepEv_28539_104_67"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="74" start="67" peptide_ref="Pep104" dBSequence_ref="DBSeq29285" id="PepEv_29351_104_67"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="74" start="67" peptide_ref="Pep104" dBSequence_ref="DBSeq37511" id="PepEv_37577_104_67"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="R" end="211" start="206" peptide_ref="Pep105" dBSequence_ref="DBSeq105830" id="PepEv_106035_105_206"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="R" end="211" start="206" peptide_ref="Pep105" dBSequence_ref="DBSeq106550" id="PepEv_106755_105_206"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="R" end="211" start="206" peptide_ref="Pep105" dBSequence_ref="DBSeq110897" id="PepEv_111102_105_206"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="V" end="4971" start="4961" peptide_ref="Pep106" dBSequence_ref="DBSeq9505" id="PepEv_14465_106_4961"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="V" end="2929" start="2919" peptide_ref="Pep106" dBSequence_ref="DBSeq17116" id="PepEv_20034_106_2919"/>
+    <PeptideEvidence isDecoy="false" post="A" pre="V" end="2853" start="2843" peptide_ref="Pep106" dBSequence_ref="DBSeq38514" id="PepEv_41356_106_2843"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="P" end="156" start="150" peptide_ref="Pep107" dBSequence_ref="DBSeq87068" id="PepEv_87217_107_150"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="P" end="156" start="150" peptide_ref="Pep107" dBSequence_ref="DBSeq87837" id="PepEv_87986_107_150"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="P" end="156" start="150" peptide_ref="Pep107" dBSequence_ref="DBSeq88550" id="PepEv_88699_107_150"/>
+    <PeptideEvidence isDecoy="true" post="Q" pre="P" end="156" start="150" peptide_ref="Pep107" dBSequence_ref="DBSeq103640" id="PepEv_103789_107_150"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="K" end="322" start="315" peptide_ref="Pep108" dBSequence_ref="DBSeq60575" id="PepEv_60889_108_315"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="K" end="322" start="315" peptide_ref="Pep108" dBSequence_ref="DBSeq61828" id="PepEv_62142_108_315"/>
+    <PeptideEvidence isDecoy="true" post="Y" pre="K" end="322" start="315" peptide_ref="Pep108" dBSequence_ref="DBSeq89848" id="PepEv_90162_108_315"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="K" end="29" start="22" peptide_ref="Pep109" dBSequence_ref="DBSeq63026" id="PepEv_63047_109_22"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="K" end="29" start="22" peptide_ref="Pep109" dBSequence_ref="DBSeq63881" id="PepEv_63902_109_22"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="K" end="29" start="22" peptide_ref="Pep109" dBSequence_ref="DBSeq91148" id="PepEv_91169_109_22"/>
+    <PeptideEvidence isDecoy="true" post="L" pre="K" end="29" start="22" peptide_ref="Pep109" dBSequence_ref="DBSeq92003" id="PepEv_92024_109_22"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="89" start="81" peptide_ref="Pep110" dBSequence_ref="DBSeq7051" id="PepEv_7131_110_81"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="89" start="81" peptide_ref="Pep110" dBSequence_ref="DBSeq7906" id="PepEv_7986_110_81"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="89" start="81" peptide_ref="Pep110" dBSequence_ref="DBSeq35173" id="PepEv_35253_110_81"/>
+    <PeptideEvidence isDecoy="false" post="K" pre="R" end="89" start="81" peptide_ref="Pep110" dBSequence_ref="DBSeq36028" id="PepEv_36108_110_81"/>
+    <PeptideEvidence isDecoy="false" post="R" pre="K" end="96" start="89" peptide_ref="Pep111" dBSequence_ref="DBSeq23875" id="PepEv_23963_111_89"/>
+    <PeptideEvidence isDecoy="false" post="R" pre="K" end="96" start="89" peptide_ref="Pep111" dBSequence_ref="DBSeq46340" id="PepEv_46428_111_89"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="211" start="197" peptide_ref="Pep112" dBSequence_ref="DBSeq78837" id="PepEv_79033_112_197"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="204" start="190" peptide_ref="Pep112" dBSequence_ref="DBSeq79051" id="PepEv_79240_112_190"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="204" start="190" peptide_ref="Pep112" dBSequence_ref="DBSeq79258" id="PepEv_79447_112_190"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="204" start="190" peptide_ref="Pep112" dBSequence_ref="DBSeq79465" id="PepEv_79654_112_190"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="175" start="161" peptide_ref="Pep112" dBSequence_ref="DBSeq79672" id="PepEv_79832_112_161"/>
+    <PeptideEvidence isDecoy="true" post="K" pre="K" end="212" start="198" peptide_ref="Pep112" dBSequence_ref="DBSeq100983" id="PepEv_101180_112_198"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="304" start="292" peptide_ref="Pep113" dBSequence_ref="DBSeq9505" id="PepEv_9796_113_292"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="304" start="292" peptide_ref="Pep113" dBSequence_ref="DBSeq17116" id="PepEv_17407_113_292"/>
+    <PeptideEvidence isDecoy="false" post="F" pre="K" end="228" start="216" peptide_ref="Pep113" dBSequence_ref="DBSeq38514" id="PepEv_38729_113_216"/>
+</SequenceCollection>
+<AnalysisCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <SpectrumIdentification spectrumIdentificationList_ref="SI_LIST_1" spectrumIdentificationProtocol_ref="SearchProtocol_1" id="SpecIdent_1">
+        <InputSpectra spectraData_ref="SID_1"/>
+        <SearchDatabaseRef searchDatabase_ref="SearchDB_1"/>
+    </SpectrumIdentification>
+</AnalysisCollection>
+<AnalysisProtocolCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <SpectrumIdentificationProtocol analysisSoftware_ref="ID_software" id="SearchProtocol_1">
+        <SearchType>
+            <cvParam accession="MS:1001083" cvRef="PSI-MS" name="ms-ms search"/>
+        </SearchType>
+        <AdditionalSearchParams>
+            <cvParam accession="MS:1001211" cvRef="PSI-MS" name="parent mass type mono"/>
+            <cvParam accession="MS:1001256" cvRef="PSI-MS" name="fragment mass type mono"/>
+            <userParam value="true" name="TargetDecoyApproach"/>
+            <userParam value="0" name="MinIsotopeError"/>
+            <userParam value="1" name="MaxIsotopeError"/>
+            <userParam value="As written in the spectrum or CID if no info" name="FragmentMethod"/>
+            <userParam value="LowRes" name="Instrument"/>
+            <userParam value="Standard" name="Protocol"/>
+            <userParam value="1" name="NumTolerableTermini"/>
+            <userParam value="1" name="NumMatchesPerSpec"/>
+            <userParam value="2" name="MaxNumModifications"/>
+            <userParam value="6" name="MinPepLength"/>
+            <userParam value="40" name="MaxPepLength"/>
+            <userParam value="2" name="MinCharge"/>
+            <userParam value="3" name="MaxCharge"/>
+        </AdditionalSearchParams>
+        <ModificationParams/>
+        <Enzymes>
+            <Enzyme missedCleavages="1000" semiSpecific="true" id="Tryp">
+                <EnzymeName>
+                    <cvParam accession="MS:1001251" cvRef="PSI-MS" name="Trypsin"/>
+                </EnzymeName>
+            </Enzyme>
+        </Enzymes>
+        <ParentTolerance>
+            <cvParam accession="MS:1001412" cvRef="PSI-MS" unitCvRef="UO" unitName="parts per million" unitAccession="UO:0000169" value="50.0" name="search tolerance plus value"/>
+            <cvParam accession="MS:1001413" cvRef="PSI-MS" unitCvRef="UO" unitName="parts per million" unitAccession="UO:0000169" value="50.0" name="search tolerance minus value"/>
+        </ParentTolerance>
+        <Threshold>
+            <cvParam accession="MS:1001494" cvRef="PSI-MS" name="no threshold"/>
+        </Threshold>
+    </SpectrumIdentificationProtocol>
+</AnalysisProtocolCollection>
+<DataCollection xmlns="http://psidev.info/psi/pi/mzIdentML/1.1">
+    <Inputs>
+        <SearchDatabase numDatabaseSequences="144" location="/tmp/tmpLUdxSj/job_working_directory/000/3/cow.protein.PRG2012-subset.fasta" id="SearchDB_1">
+            <FileFormat>
+                <cvParam accession="MS:1001348" cvRef="PSI-MS" name="FASTA format"/>
+            </FileFormat>
+            <DatabaseName>
+                <userParam name="cow.protein.PRG2012-subset.fasta"/>
+            </DatabaseName>
+            <cvParam accession="MS:1001197" cvRef="PSI-MS" name="DB composition target+decoy"/>
+            <cvParam accession="MS:1001283" cvRef="PSI-MS" value="^XXX" name="decoy DB accession regexp"/>
+            <cvParam accession="MS:1001195" cvRef="PSI-MS" name="decoy DB type reverse"/>
+        </SearchDatabase>
+        <SpectraData location="/tmp/tmpLUdxSj/job_working_directory/000/3/201208-378803.mzML" name="201208-378803.mzML" id="SID_1">
+            <FileFormat>
+                <cvParam accession="MS:1000584" cvRef="PSI-MS" name="mzML file"/>
+            </FileFormat>
+            <SpectrumIDFormat>
+                <cvParam accession="MS:1000770" cvRef="PSI-MS" name="WIFF nativeID format"/>
+            </SpectrumIDFormat>
+        </SpectraData>
+    </Inputs>
+    <AnalysisData>
+        <SpectrumIdentificationList id="SI_LIST_1">
+            <FragmentationTable>
+                <Measure id="Measure_MZ">
+                    <cvParam accession="MS:1001225" cvRef="PSI-MS" unitCvRef="PSI-MS" unitName="m/z" unitAccession="MS:1000040" name="product ion m/z"/>
+                </Measure>
+            </FragmentationTable>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1224 experiment=2" id="SIR_86">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep1" calculatedMassToCharge="576.2904663085938" experimentalMassToCharge="576.2933349609375" chargeState="3" id="SII_86_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84238_1_607"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85050_1_603"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85817_1_558"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_93903_1_418"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="4" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="57" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.778316E-8" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.003944279" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=2" id="SIR_39">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep2" calculatedMassToCharge="451.93316650390625" experimentalMassToCharge="452.254638671875" chargeState="3" id="SII_39_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_31410_2_318"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_32123_2_262"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_32809_2_235"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_47926_2_262"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="7" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="54" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.911494E-7" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.0355328" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1215 experiment=4" id="SIR_64">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep3" calculatedMassToCharge="673.8528442382812" experimentalMassToCharge="674.3531494140625" chargeState="2" id="SII_64_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_47057_3_213"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-1" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="62" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.9064777E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.076016985" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1211 experiment=5" id="SIR_49">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep4" calculatedMassToCharge="497.9245300292969" experimentalMassToCharge="498.2347412109375" chargeState="3" id="SII_49_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_105272_4_920"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_108178_4_952"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_109278_4_920"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_110378_4_920"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="0" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="49" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.5485353E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.10241799" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1219 experiment=4" id="SIR_79">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep5" calculatedMassToCharge="482.2301330566406" experimentalMassToCharge="482.21160888671875" chargeState="2" id="SII_79_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_47594_5_489"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-4" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.6478965E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.10364397" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1207 experiment=3" id="SIR_36">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep6" calculatedMassToCharge="467.2357482910156" experimentalMassToCharge="467.236083984375" chargeState="3" id="SII_36_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44505_6_569"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-6" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="57" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.189995E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.12719467" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.5" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.5" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1239 experiment=2" id="SIR_102">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep7" calculatedMassToCharge="485.8894958496094" experimentalMassToCharge="486.2041320800781" chargeState="3" id="SII_102_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72991_7_7512"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_78490_7_5400"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99888_7_5400"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-11" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.136259E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.20479806" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="0.75" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="0.75" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1212 experiment=3" id="SIR_51">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep8" calculatedMassToCharge="576.9359130859375" experimentalMassToCharge="577.2473754882812" chargeState="3" id="SII_51_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100134_8_223"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="3" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="101" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.329578E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.21497919" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1210 experiment=4" id="SIR_45">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep9" calculatedMassToCharge="547.2616577148438" experimentalMassToCharge="547.7760620117188" chargeState="2" id="SII_45_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_67474_9_1995"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_75015_9_1925"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_96413_9_1925"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-7" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="41" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.260432E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.28565443" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1235 experiment=2" id="SIR_98">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep10" calculatedMassToCharge="667.3414306640625" experimentalMassToCharge="667.8607788085938" chargeState="2" id="SII_98_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_60613_10_39"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_61866_10_39"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89886_10_39"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-11" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="67" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.413187E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.29435542" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1212 experiment=4" id="SIR_52">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep11" calculatedMassToCharge="598.323974609375" experimentalMassToCharge="598.3059692382812" chargeState="3" id="SII_52_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_16693_11_7189"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_22258_11_5143"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_43580_11_5067"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-8" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="65" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.5034735E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.34040257" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1217 experiment=2" id="SIR_69">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep12" calculatedMassToCharge="501.76434326171875" experimentalMassToCharge="501.7442626953125" chargeState="2" id="SII_69_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12182_12_2678"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="15" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="81" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.546935E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.3362706" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1223 experiment=2" id="SIR_84">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep13" calculatedMassToCharge="610.784423828125" experimentalMassToCharge="610.7609252929688" chargeState="2" id="SII_84_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_13770_13_4266"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_19339_13_2224"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_40661_13_2148"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="3" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="96" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.9886025E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.35534644" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1428 experiment=2" id="SIR_105">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep14" calculatedMassToCharge="584.772705078125" experimentalMassToCharge="585.301513671875" chargeState="2" id="SII_105_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_93047_14_190"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-15" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="77" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.87155E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.38838625" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1283 experiment=2" id="SIR_104">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep15" calculatedMassToCharge="591.2969360351562" experimentalMassToCharge="591.3255615234375" chargeState="3" id="SII_104_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63753_15_728"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_64608_15_728"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_91875_15_728"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_92730_15_728"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-5" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="87" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.987389E-6" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.4013632" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1210 experiment=2" id="SIR_43">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep16" calculatedMassToCharge="596.7909545898438" experimentalMassToCharge="597.2890625" chargeState="2" id="SII_43_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9220_16_460"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="0" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="93" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.0661531E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.42148226" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1216 experiment=5" id="SIR_68">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep17" calculatedMassToCharge="575.8055419921875" experimentalMassToCharge="575.8047485351562" chargeState="2" id="SII_68_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_103307_17_227"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="8" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="72" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.1603542E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.46074182" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1217 experiment=4" id="SIR_71">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep18" calculatedMassToCharge="571.3450317382812" experimentalMassToCharge="571.8231811523438" chargeState="2" id="SII_71_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_14994_18_5490"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_20563_18_3448"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_41885_18_3372"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-1" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="59" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.18926155E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.47015077" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1223 experiment=3" id="SIR_85">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep19" calculatedMassToCharge="478.26397705078125" experimentalMassToCharge="478.24365234375" chargeState="2" id="SII_85_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_5629_19_1030"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_6827_19_975"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_34949_19_1077"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-16" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.2600591E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.49813917" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1214 experiment=5" id="SIR_61">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep20" calculatedMassToCharge="519.640869140625" experimentalMassToCharge="519.6590576171875" chargeState="3" id="SII_61_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29231_20_759"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-5" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.9413415E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.780167" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1204 experiment=3" id="SIR_32">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep21" calculatedMassToCharge="722.4049682617188" experimentalMassToCharge="722.7725830078125" chargeState="3" id="SII_32_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72627_21_7148"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_78126_21_5036"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99524_21_5036"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-16" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="82" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.0022577E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.8135574" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1231 experiment=2" id="SIR_96">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep22" calculatedMassToCharge="489.9119567871094" experimentalMassToCharge="490.2488098144531" chargeState="3" id="SII_96_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27908_22_252"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_28724_22_252"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29536_22_252"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_37762_22_252"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-18" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="65" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.1515163E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.8612735" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1236 experiment=2" id="SIR_99">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep23" calculatedMassToCharge="481.73980712890625" experimentalMassToCharge="482.2271423339844" chargeState="2" id="SII_99_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_60768_23_194"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_62021_23_194"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_90041_23_194"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-6" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="67" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.2036973E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.86257124" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1220 experiment=2" id="SIR_80">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep24" calculatedMassToCharge="409.8983459472656" experimentalMassToCharge="410.2142639160156" chargeState="3" id="SII_80_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_13046_24_3542"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-8" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="51" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.3277607E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.9202336" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1203 experiment=3" id="SIR_30">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep25" calculatedMassToCharge="519.742919921875" experimentalMassToCharge="520.2384033203125" chargeState="2" id="SII_30_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_83736_25_105"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84548_25_101"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85315_25_56"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-1" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="55" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.5448287E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="0.99609685" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1181 experiment=2" id="SIR_1">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep26" calculatedMassToCharge="506.2500305175781" experimentalMassToCharge="506.7447204589844" chargeState="2" id="SII_1_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10101_26_597"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17712_26_597"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39034_26_521"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-17" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="35" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.9523253E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.1555992" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1202 experiment=2" id="SIR_27">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep27" calculatedMassToCharge="489.2486877441406" experimentalMassToCharge="489.23614501953125" chargeState="3" id="SII_27_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_16054_27_6550"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_21623_27_4508"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42945_27_4432"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-17" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="75" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.1620126E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.270718" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1207 experiment=2" id="SIR_35">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep28" calculatedMassToCharge="540.2278442382812" experimentalMassToCharge="540.2457885742188" chargeState="3" id="SII_35_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_105372_28_1020"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_108278_28_1052"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_109378_28_1020"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_110478_28_1020"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-15" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="77" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.191305E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.2824897" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1222 experiment=2" id="SIR_83">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep29" calculatedMassToCharge="582.3135986328125" experimentalMassToCharge="582.2852172851562" chargeState="3" id="SII_83_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10016_29_512"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17627_29_512"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38949_29_436"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-17" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="94" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.4877667E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.4119875" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1229 experiment=3" id="SIR_91">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep30" calculatedMassToCharge="710.7939453125" experimentalMassToCharge="710.8026733398438" chargeState="2" id="SII_91_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_801_30_554"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_1418_30_554"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_2035_30_554"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_2651_30_553"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3248_30_534"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3837_30_526"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_24557_30_554"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_25174_30_554"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_25791_30_554"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_26407_30_553"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27004_30_534"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27593_30_526"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="53" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.7364465E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.495737" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=3" id="SIR_55">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep31" calculatedMassToCharge="547.2713012695312" experimentalMassToCharge="547.2749633789062" chargeState="2" id="SII_55_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_64768_31_33"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-14" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="42" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.915081E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.532441" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1219 experiment=2" id="SIR_77">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep32" calculatedMassToCharge="487.2510681152344" experimentalMassToCharge="487.2433166503906" chargeState="3" id="SII_77_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_14282_32_4778"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_19851_32_2736"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_41173_32_2660"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-10" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="80" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.2131483E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.6799086" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1228 experiment=3" id="SIR_89">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep33" calculatedMassToCharge="605.7780151367188" experimentalMassToCharge="606.2748413085938" chargeState="2" id="SII_89_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9896_33_392"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17507_33_392"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38829_33_316"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="36" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.2569478E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.6748536" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=3" id="SIR_40">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep34" calculatedMassToCharge="570.3568115234375" experimentalMassToCharge="570.7028198242188" chargeState="3" id="SII_40_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_5618_34_1019"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_6816_34_964"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_34938_34_1066"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-13" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="89" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.495753E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.8067082" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1192 experiment=2" id="SIR_10">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep35" calculatedMassToCharge="442.91363525390625" experimentalMassToCharge="443.2386779785156" chargeState="3" id="SII_10_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_70903_35_5424"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-11" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.838571E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.9292834" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1218 experiment=4" id="SIR_75">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep36" calculatedMassToCharge="647.343505859375" experimentalMassToCharge="647.8163452148438" chargeState="2" id="SII_75_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_67447_36_1968"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_74988_36_1898"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_96386_36_1898"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="49" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.8764297E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.9277989" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep37" calculatedMassToCharge="647.3038940429688" experimentalMassToCharge="647.8163452148438" chargeState="2" id="SII_75_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_105840_37_11"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106560_37_11"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_110907_37_11"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="49" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.8764297E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.9277989" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1216 experiment=2" id="SIR_65">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep38" calculatedMassToCharge="463.9016418457031" experimentalMassToCharge="464.21527099609375" chargeState="3" id="SII_65_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_11117_38_1613"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-17" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="61" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.9378592E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="1.9688725" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1193 experiment=2" id="SIR_12">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep39" calculatedMassToCharge="458.7241516113281" experimentalMassToCharge="458.7034606933594" chargeState="2" id="SII_12_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_66874_39_1395"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_74415_39_1325"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_95813_39_1325"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="15" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="103" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.257032E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.046142" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1212 experiment=2" id="SIR_50">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep40" calculatedMassToCharge="652.9561767578125" experimentalMassToCharge="653.3101806640625" chargeState="3" id="SII_50_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_49367_40_990"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_52273_40_1022"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_53373_40_990"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_54473_40_990"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-14" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="87" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.4227086E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.1953294" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=5" id="SIR_57">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep41" calculatedMassToCharge="575.3118286132812" experimentalMassToCharge="575.3018188476562" chargeState="2" id="SII_57_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106357_41_528"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_107077_41_528"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_111424_41_528"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.5088716E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.1674106" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1229 experiment=4" id="SIR_92">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep42" calculatedMassToCharge="832.825439453125" experimentalMassToCharge="832.8515625" chargeState="3" id="SII_92_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_83890_42_259"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84702_42_255"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85469_42_210"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_93555_42_70"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-25" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="107" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.553615E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.2965865" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1234 experiment=2" id="SIR_97">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep43" calculatedMassToCharge="516.2300415039062" experimentalMassToCharge="516.2442626953125" chargeState="2" id="SII_97_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_66353_43_874"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_73894_43_804"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_95292_43_804"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-5" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="67" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.5706063E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.1916993" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1580 experiment=2" id="SIR_106">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep44" calculatedMassToCharge="532.9508666992188" experimentalMassToCharge="533.2622680664062" chargeState="3" id="SII_106_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_324_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_941_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_1558_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_2175_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_2771_44_57"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3360_44_49"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_24080_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_24697_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_25314_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_25931_44_77"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_26527_44_57"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27116_44_49"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-31" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="38" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.964108E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.387492" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1212 experiment=5" id="SIR_53">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep45" calculatedMassToCharge="584.2821044921875" experimentalMassToCharge="584.6378784179688" chargeState="3" id="SII_53_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_68969_45_3490"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_76510_45_3420"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_97908_45_3420"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-14" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="53" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.189589E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.505793" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1191 experiment=3" id="SIR_9">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep46" calculatedMassToCharge="400.6896057128906" experimentalMassToCharge="400.6839294433594" chargeState="2" id="SII_9_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15267_46_5763"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_20836_46_3721"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42158_46_3645"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-14" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="27" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.842939E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.6465752" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1191 experiment=2" id="SIR_8">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep47" calculatedMassToCharge="435.212890625" experimentalMassToCharge="435.7113037109375" chargeState="2" id="SII_8_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100177_47_266"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-9" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="59" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.040255E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.7402081" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1187 experiment=2" id="SIR_4">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep48" calculatedMassToCharge="441.2059326171875" experimentalMassToCharge="441.6909484863281" chargeState="2" id="SII_4_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_56555_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_57172_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_57789_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_58406_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_59022_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_59619_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_80311_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_80928_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_81545_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_82162_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_82778_48_333"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_83375_48_333"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-17" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="76" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.454565E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="2.9178658" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=5" id="SIR_42">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep49" calculatedMassToCharge="404.2010192871094" experimentalMassToCharge="404.19219970703125" chargeState="3" id="SII_42_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_23958_49_84"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46423_49_84"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-14" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="51" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.684107E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.037758" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1202 experiment=3" id="SIR_28">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep50" calculatedMassToCharge="423.6850280761719" experimentalMassToCharge="423.6785888671875" chargeState="2" id="SII_28_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_43973_50_37"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-12" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="36" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.7868164E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.0307846" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1215 experiment=3" id="SIR_63">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep51" calculatedMassToCharge="613.30859375" experimentalMassToCharge="613.7810668945312" chargeState="2" id="SII_63_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12725_51_3221"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="53" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.023354E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.1718724" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1627 experiment=2" id="SIR_108">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep52" calculatedMassToCharge="582.2919921875" experimentalMassToCharge="582.2650756835938" chargeState="3" id="SII_108_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_67443_52_1964"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_74984_52_1894"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_96382_52_1894"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-44" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="44" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.592158E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.4529305" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1198 experiment=3" id="SIR_18">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep53" calculatedMassToCharge="612.79638671875" experimentalMassToCharge="613.275634765625" chargeState="2" id="SII_18_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_13593_53_4089"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_19162_53_2047"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_40484_53_1971"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-29" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.59888E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.3993952" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1219 experiment=3" id="SIR_78">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep54" calculatedMassToCharge="509.2572326660156" experimentalMassToCharge="509.2569580078125" chargeState="2" id="SII_78_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12037_54_2533"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-23" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="42" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.931347E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.5139492" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1583 experiment=2" id="SIR_107">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep55" calculatedMassToCharge="487.25946044921875" experimentalMassToCharge="487.24053955078125" chargeState="3" id="SII_107_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_70854_55_5375"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-27" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.3443494E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.7406363" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1192 experiment=3" id="SIR_11">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep56" calculatedMassToCharge="433.20782470703125" experimentalMassToCharge="433.1874694824219" chargeState="2" id="SII_11_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9213_56_453"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-20" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="34" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.6144715E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.7421446" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1217 experiment=3" id="SIR_70">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep57" calculatedMassToCharge="532.7318725585938" experimentalMassToCharge="533.2589111328125" chargeState="2" id="SII_70_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72116_57_6637"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77617_57_4527"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99015_57_4527"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-19" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="100" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.8740595E-5" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="3.88485" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1204 experiment=2" id="SIR_31">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep58" calculatedMassToCharge="623.27490234375" experimentalMassToCharge="623.2515258789062" chargeState="2" id="SII_31_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79882_58_33"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_102347_58_33"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-16" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="100" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.0204326E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.034076" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1230 experiment=2" id="SIR_94">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep59" calculatedMassToCharge="814.3717041015625" experimentalMassToCharge="814.3682250976562" chargeState="3" id="SII_94_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100235_59_324"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-29" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="136" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.03722596E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.289241" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1211 experiment=3" id="SIR_47">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep60" calculatedMassToCharge="507.24029541015625" experimentalMassToCharge="507.2287902832031" chargeState="3" id="SII_47_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_94324_60_212"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_105665_60_213"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-23" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="65" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.0949449E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.383174" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1229 experiment=5" id="SIR_93">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep61" calculatedMassToCharge="633.793212890625" experimentalMassToCharge="633.7722778320312" chargeState="2" id="SII_93_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63770_61_745"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_64625_61_745"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_91892_61_745"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_92747_61_745"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-27" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="79" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.1053563E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.389038" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1211 experiment=2" id="SIR_46">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep62" calculatedMassToCharge="442.1770324707031" experimentalMassToCharge="442.1819763183594" chargeState="2" id="SII_46_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_103572_62_492"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-13" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="63" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.1065043E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.306736" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1209 experiment=4" id="SIR_41">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep63" calculatedMassToCharge="481.2167053222656" experimentalMassToCharge="481.1990051269531" chargeState="2" id="SII_41_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_28260_63_604"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29076_63_604"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29888_63_604"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-31" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="46" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.1874728E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.648006" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1215 experiment=2" id="SIR_62">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep64" calculatedMassToCharge="605.2803955078125" experimentalMassToCharge="605.810546875" chargeState="2" id="SII_62_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_69145_64_3666"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_76686_64_3596"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_98084_64_3596"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.2084616E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.7545714" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep49" calculatedMassToCharge="605.7979125976562" experimentalMassToCharge="605.810546875" chargeState="2" id="SII_62_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_23958_49_84"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46423_49_84"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.2084616E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.7774115" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="3" peptide_ref="Pep65" calculatedMassToCharge="605.3310546875" experimentalMassToCharge="605.810546875" chargeState="2" id="SII_62_3">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15572_65_6068"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_21141_65_4026"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42463_65_3950"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.2084616E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.7984385" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1196 experiment=2" id="SIR_15">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep66" calculatedMassToCharge="408.69232177734375" experimentalMassToCharge="409.1874694824219" chargeState="2" id="SII_15_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_30156_66_105"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44955_66_105"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-16" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="43" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.217629E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.709302" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1214 experiment=2" id="SIR_58">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep67" calculatedMassToCharge="510.1940612792969" experimentalMassToCharge="510.2083740234375" chargeState="2" id="SII_58_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9232_67_472"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-20" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="67" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.2431844E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="4.891185" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1188 experiment=3" id="SIR_6">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep68" calculatedMassToCharge="428.210693359375" experimentalMassToCharge="428.7035217285156" chargeState="2" id="SII_6_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72145_68_6666"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77646_68_4556"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99044_68_4556"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-16" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="93" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.4716851E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="5.7280927" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1221 experiment=2" id="SIR_81">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep69" calculatedMassToCharge="412.1952209472656" experimentalMassToCharge="412.68389892578125" chargeState="2" id="SII_81_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_71732_69_6253"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77233_69_4143"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_98631_69_4143"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.4825392E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="5.770339" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep70" calculatedMassToCharge="412.1976013183594" experimentalMassToCharge="412.68389892578125" chargeState="2" id="SII_81_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_105844_70_15"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106564_70_15"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_110911_70_15"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="47" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.4825392E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="5.7338686" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1217 experiment=5" id="SIR_72">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep71" calculatedMassToCharge="476.213623046875" experimentalMassToCharge="476.6978454589844" chargeState="2" id="SII_72_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_7575_71_525"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_8430_71_525"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_35697_71_525"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_36552_71_525"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-25" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="35" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.4944564E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="5.8797894" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1218 experiment=2" id="SIR_73">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep72" calculatedMassToCharge="577.791748046875" experimentalMassToCharge="577.770751953125" chargeState="2" id="SII_73_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_61519_72_945"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_62771_72_944"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_90792_72_945"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-22" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="45" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.570459E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="6.2084956" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1238 experiment=2" id="SIR_101">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep73" calculatedMassToCharge="455.3005065917969" experimentalMassToCharge="455.6540832519531" chargeState="3" id="SII_101_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_36895_73_13"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-35" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="25" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.6960995E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="6.70519" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1201 experiment=2" id="SIR_24">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep74" calculatedMassToCharge="439.69287109375" experimentalMassToCharge="440.1820373535156" chargeState="2" id="SII_24_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12435_74_2931"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-21" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="44" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.7229663E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="6.706129" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1210 experiment=3" id="SIR_44">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep75" calculatedMassToCharge="461.7023620605469" experimentalMassToCharge="461.7162170410156" chargeState="2" id="SII_44_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44524_75_588"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-18" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="59" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.7894078E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="7.040246" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1218 experiment=3" id="SIR_74">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep76" calculatedMassToCharge="470.9001770019531" experimentalMassToCharge="471.2165222167969" chargeState="3" id="SII_74_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12758_76_3254"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-27" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="57" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.8095516E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="7.215225" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1203 experiment=2" id="SIR_29">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep77" calculatedMassToCharge="533.7360229492188" experimentalMassToCharge="533.7421264648438" chargeState="2" id="SII_29_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63045_77_20"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63900_77_20"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_91167_77_20"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_92022_77_20"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-24" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="87" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="1.9512225E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="7.7137675" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1200 experiment=3" id="SIR_22">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep78" calculatedMassToCharge="449.8872985839844" experimentalMassToCharge="450.2027587890625" chargeState="3" id="SII_22_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106237_78_408"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106957_78_408"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_111304_78_408"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-22" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="55" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.0906812E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="8.336173" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1221 experiment=3" id="SIR_82">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep79" calculatedMassToCharge="684.8268432617188" experimentalMassToCharge="684.796142578125" chargeState="2" id="SII_82_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15510_79_6006"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_21079_79_3964"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42401_79_3888"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="85" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.1989181E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="8.731244" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep80" calculatedMassToCharge="684.2944946289062" experimentalMassToCharge="684.796142578125" chargeState="2" id="SII_82_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_105153_80_801"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_108027_80_801"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_109159_80_801"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_110259_80_801"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="85" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.1989181E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="8.767746" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1214 experiment=3" id="SIR_59">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep81" calculatedMassToCharge="493.2185363769531" experimentalMassToCharge="493.2047424316406" chargeState="3" id="SII_59_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_100431_81_520"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-35" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="82" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="2.555741E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="10.270757" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1216 experiment=3" id="SIR_66">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep82" calculatedMassToCharge="501.2195739746094" experimentalMassToCharge="501.203125" chargeState="3" id="SII_66_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_103294_82_214"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="54" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.082045E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="12.385815" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1199 experiment=2" id="SIR_19">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep83" calculatedMassToCharge="608.2769775390625" experimentalMassToCharge="608.2568969726562" chargeState="3" id="SII_19_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_15505_83_6001"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_21074_83_3959"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_42396_83_3883"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-38" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="76" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.0840118E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="12.439979" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1201 experiment=4" id="SIR_26">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep84" calculatedMassToCharge="792.8681030273438" experimentalMassToCharge="792.8330078125" chargeState="2" id="SII_26_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_12639_84_3135"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-57" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="70" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.212409E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="12.909707" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1197 experiment=2" id="SIR_16">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep85" calculatedMassToCharge="473.8797912597656" experimentalMassToCharge="474.2104797363281" chargeState="3" id="SII_16_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_103577_85_497"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="58" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.288899E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="13.113828" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1214 experiment=4" id="SIR_60">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep86" calculatedMassToCharge="545.5704956054688" experimentalMassToCharge="545.8875732421875" chargeState="3" id="SII_60_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38290_86_153"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_49630_86_153"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-12" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="120" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.4639085E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="13.972368" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep87" calculatedMassToCharge="545.56103515625" experimentalMassToCharge="545.8875732421875" chargeState="3" id="SII_60_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_48831_87_454"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_51737_87_486"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_52837_87_454"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_53937_87_454"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-12" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="120" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.4639085E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="14.023288" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=2" id="SIR_54">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep88" calculatedMassToCharge="497.7185363769531" experimentalMassToCharge="497.6971435546875" chargeState="2" id="SII_54_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_60680_88_106"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_61933_88_106"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_89953_88_106"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-28" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="49" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.6034102E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="14.104468" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1225 experiment=2" id="SIR_87">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep89" calculatedMassToCharge="550.730224609375" experimentalMassToCharge="550.7279052734375" chargeState="2" id="SII_87_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_7306_89_256"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_8161_89_256"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_35428_89_256"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_36283_89_256"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-39" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="46" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="3.8618056E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="15.193888" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1281 experiment=2" id="SIR_103">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep90" calculatedMassToCharge="591.767333984375" experimentalMassToCharge="591.745361328125" chargeState="2" id="SII_103_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_70817_90_5338"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="54" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.2281268E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="16.715054" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1230 experiment=3" id="SIR_95">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep91" calculatedMassToCharge="613.267333984375" experimentalMassToCharge="613.2512817382812" chargeState="3" id="SII_95_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_72297_91_6818"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_77796_91_4706"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99194_91_4706"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="66" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.8350522E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="19.574224" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1218 experiment=5" id="SIR_76">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep92" calculatedMassToCharge="587.2727661132812" experimentalMassToCharge="587.7717895507812" chargeState="2" id="SII_76_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_5042_92_443"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_6240_92_388"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_34362_92_490"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-31" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="52" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="4.938522E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="19.69137" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1201 experiment=3" id="SIR_25">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep93" calculatedMassToCharge="512.2411499023438" experimentalMassToCharge="512.2169799804688" chargeState="2" id="SII_25_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_632_93_385"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_1249_93_385"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_1866_93_385"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_2482_93_384"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3079_93_365"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_3668_93_357"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_24388_93_385"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_25005_93_385"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_25622_93_385"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_26238_93_384"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_26835_93_365"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27424_93_357"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-26" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="44" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.290015E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="20.813036" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1208 experiment=3" id="SIR_38">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep94" calculatedMassToCharge="490.22198486328125" experimentalMassToCharge="490.20404052734375" chargeState="2" id="SII_38_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9833_94_329"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17444_94_329"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38766_94_253"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-34" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="76" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="5.55107E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="21.727999" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1204 experiment=4" id="SIR_33">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep95" calculatedMassToCharge="463.68768310546875" experimentalMassToCharge="464.1875305175781" chargeState="2" id="SII_33_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_30190_95_139"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_44989_95_139"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-44" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="32" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.305883E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="24.682487" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep96" calculatedMassToCharge="464.1719665527344" experimentalMassToCharge="464.1875305175781" chargeState="2" id="SII_33_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63479_96_454"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_64334_96_454"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_91601_96_454"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_92456_96_454"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-44" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="32" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.305883E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="24.543758" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1208 experiment=2" id="SIR_37">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep97" calculatedMassToCharge="621.2733154296875" experimentalMassToCharge="621.2553100585938" chargeState="2" id="SII_37_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106201_97_372"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106921_97_372"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_111268_97_372"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-40" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="77" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="6.3325354E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="25.543549" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1194 experiment=2" id="SIR_14">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep98" calculatedMassToCharge="451.87249755859375" experimentalMassToCharge="452.1972351074219" chargeState="3" id="SII_14_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_69471_98_3992"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-42" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="59" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="7.1842485E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="28.645754" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1213 experiment=4" id="SIR_56">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep99" calculatedMassToCharge="413.19049072265625" experimentalMassToCharge="413.6736755371094" chargeState="2" id="SII_56_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_84403_99_772"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85215_99_768"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_85982_99_723"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_94068_99_583"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-33" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="43" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="8.442974E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="32.861744" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1200 experiment=2" id="SIR_21">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep100" calculatedMassToCharge="563.2036743164062" experimentalMassToCharge="563.2123413085938" chargeState="2" id="SII_21_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_13866_100_4362"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_19435_100_2320"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_40757_100_2244"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-44" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="79" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.1590727E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="36.20856" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1183 experiment=2" id="SIR_2">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep101" calculatedMassToCharge="416.161376953125" experimentalMassToCharge="416.1649169921875" chargeState="2" id="SII_2_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_10076_101_572"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17687_101_572"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_39009_101_496"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-39" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="52" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.4161194E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="36.417786" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1211 experiment=4" id="SIR_48">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep102" calculatedMassToCharge="676.7764892578125" experimentalMassToCharge="677.2626342773438" chargeState="2" id="SII_48_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_70196_102_4717"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-50" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="37" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="9.469715E-4" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="37.908215" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1200 experiment=4" id="SIR_23">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep103" calculatedMassToCharge="553.8985595703125" experimentalMassToCharge="554.2100219726562" chargeState="3" id="SII_23_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_99924_103_13"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-46" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="41" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0010682538" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="43.247185" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1228 experiment=2" id="SIR_88">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep104" calculatedMassToCharge="500.1941833496094" experimentalMassToCharge="500.6953125" chargeState="2" id="SII_88_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_27723_104_67"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_28539_104_67"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_29351_104_67"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_37577_104_67"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-36" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="54" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0011096081" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="43.43228" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1189 experiment=2" id="SIR_7">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep105" calculatedMassToCharge="409.19061279296875" experimentalMassToCharge="409.6888122558594" chargeState="2" id="SII_7_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106035_105_206"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_106755_105_206"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_111102_105_206"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-35" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="75" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0011373081" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="43.986526" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1236 experiment=3" id="SIR_100">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep106" calculatedMassToCharge="673.8184814453125" experimentalMassToCharge="673.7861938476562" chargeState="2" id="SII_100_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_14465_106_4961"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_20034_106_2919"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_41356_106_2843"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-52" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="56" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0015187213" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="60.30387" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1198 experiment=2" id="SIR_17">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep107" calculatedMassToCharge="437.692138671875" experimentalMassToCharge="437.6932678222656" chargeState="2" id="SII_17_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_87217_107_150"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_87986_107_150"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_88699_107_150"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_103789_107_150"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-41" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="55" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0016426279" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="63.934364" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1186 experiment=2" id="SIR_3">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep108" calculatedMassToCharge="525.7091064453125" experimentalMassToCharge="526.192138671875" chargeState="2" id="SII_3_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_60889_108_315"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_62142_108_315"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_90162_108_315"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-66" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="48" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.001955566" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="76.54477" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1216 experiment=4" id="SIR_67">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep109" calculatedMassToCharge="405.1672058105469" experimentalMassToCharge="405.6540222167969" chargeState="2" id="SII_67_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63047_109_22"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_63902_109_22"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_91169_109_22"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_92024_109_22"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-44" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="24" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0019735042" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="77.246895" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1199 experiment=3" id="SIR_20">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep110" calculatedMassToCharge="494.6878967285156" experimentalMassToCharge="495.1852722167969" chargeState="2" id="SII_20_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_7131_110_81"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_7986_110_81"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_35253_110_81"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_36108_110_81"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-41" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="40" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0025026577" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="98.46456" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="1" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+                <SpectrumIdentificationItem passThreshold="true" rank="2" peptide_ref="Pep111" calculatedMassToCharge="495.1980895996094" experimentalMassToCharge="495.1852722167969" chargeState="2" id="SII_20_2">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_23963_111_89"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_46428_111_89"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-41" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="40" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0025026577" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="97.95903" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1229 experiment=2" id="SIR_90">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep112" calculatedMassToCharge="522.6652221679688" experimentalMassToCharge="522.6893920898438" chargeState="3" id="SII_90_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79033_112_197"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79240_112_190"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79447_112_190"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79654_112_190"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_79832_112_161"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_101180_112_198"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-53" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="65" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0051770797" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="208.82787" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+            <SpectrumIdentificationResult spectraData_ref="SID_1" spectrumID="sample=1 period=1 cycle=1188 experiment=2" id="SIR_5">
+                <SpectrumIdentificationItem passThreshold="true" rank="1" peptide_ref="Pep113" calculatedMassToCharge="489.1896667480469" experimentalMassToCharge="489.1662292480469" chargeState="3" id="SII_5_1">
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_9796_113_292"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_17407_113_292"/>
+                    <PeptideEvidenceRef peptideEvidence_ref="PepEv_38729_113_216"/>
+                    <cvParam accession="MS:1002049" cvRef="PSI-MS" value="-61" name="MS-GF:RawScore"/>
+                    <cvParam accession="MS:1002050" cvRef="PSI-MS" value="64" name="MS-GF:DeNovoScore"/>
+                    <cvParam accession="MS:1002052" cvRef="PSI-MS" value="0.0058590886" name="MS-GF:SpecEValue"/>
+                    <cvParam accession="MS:1002053" cvRef="PSI-MS" value="234.54517" name="MS-GF:EValue"/>
+                    <cvParam accession="MS:1002054" cvRef="PSI-MS" value="1.0" name="MS-GF:QValue"/>
+                    <cvParam accession="MS:1002055" cvRef="PSI-MS" value="1.0" name="MS-GF:PepQValue"/>
+                    <userParam value="0" name="IsotopeError"/>
+                    <userParam value="HCD" name="AssumedDissociationMethod"/>
+                </SpectrumIdentificationItem>
+            </SpectrumIdentificationResult>
+        </SpectrumIdentificationList>
+    </AnalysisData>
+</DataCollection>
+</MzIdentML>

--- a/tools/msgfplus/test-data/input/201208-378803.mzML
+++ b/tools/msgfplus/test-data/input/201208-378803.mzML
@@ -1,0 +1,1 @@
+../../../bumbershoot/myrimatch/test-data/input/201208-378803.mzML

--- a/tools/msgfplus/test-data/input/cow.protein.PRG2012-subset.fasta
+++ b/tools/msgfplus/test-data/input/cow.protein.PRG2012-subset.fasta
@@ -1,0 +1,1 @@
+../../../bumbershoot/myrimatch/test-data/input/cow.protein.PRG2012-subset.fasta

--- a/tools/msgfplus/tool_dependencies.xml
+++ b/tools/msgfplus/tool_dependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<tool_dependency>
+    <package name="msgfplus" version="10089">
+        <repository name="package_msgfplus_v10089" owner="galaxyp"/>
+    </package>
+</tool_dependency>


### PR DESCRIPTION
- add package_msgfplus_v10089
- add example output (created by searching symlinks to the Myrimatch input files)
- add common and custom mod parameters
- add functional tests

I recognize this PR may controversial as it is functionally quite redundant with Ira's MSGF wrapper. I created a standalone wrapper in galaxyp rather than forking Ira's protk version because I am doing (relatively) frequent docker deployments. Doing enough of those, it got to the point where downloading and building ruby/protk was an unnecessary delay. It also lets me make changes without juggling another repository, and it's decoupled from ProteoWizard: why not have idconvert in a separate tool? I guess because it's expected to feed the output to the TPP in the protk suite. But then why not also have TPP as a tool dependency?

The advantage of the protk version is it has some built-in databases. But there has to be a way to handle that more universally in Galaxy, like is done for data managers. Not that I've looked into that... I've just been uploading my own FASTAs.

The only advantage of my version other than not requiring protk is that it allows specifying custom mods in addition to the common mods. I opted to just put them in the XML rather than reading them from a file; it's only marginally harder to edit, and unless we're going to get the mods file from Unimod I don't see much point in the file approach. What would be really cool is a text search that looks up the mod in Unimod by name, e.g. "phospho" or "carbam". :)

I plan on porting the common mods feature to MyriMatch as well (right now it just has custom mods); would it make sense at that point to factor out the duplicate XML into macros, so that different tools are using the same masses and "common mods"? The only problem is the mod syntax is different for each engine. Hah, at that point it could make sense to go back to using a file, with one column being the name and the other columns being the specification for different engines.