### PR TITLE
Fix erroneous module name for Tabular datatype

### DIFF
--- a/tools/hardklor/datatypes_conf.xml
+++ b/tools/hardklor/datatypes_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <datatypes>
   <registration>
-    <datatype extension="hk" type="galaxy.datatypes.text:Tabular" subclass="true" />
-    <datatype extension="kr" type="galaxy.datatypes.text:Tabular" subclass="true" />
+    <datatype extension="hk" type="galaxy.datatypes.tabular:Tabular" subclass="true" />
+    <datatype extension="kr" type="galaxy.datatypes.tabular:Tabular" subclass="true" />
   </registration>
 </datatypes>


### PR DESCRIPTION
This is a small fix to address the incorrectly specified datatype modules in hardklor's datatypes_conf.xml.