### PR TITLE
Msgf+ on mzml/fasta pairs

### DIFF
--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -13,11 +13,18 @@
     </stdio>
     <command>
 <![CDATA[
-        #set $db_name = $d.display_name.replace(".fasta", "") + ".fasta"
-        #set $input_name = $s.display_name
+        #if $msgf_input.intype_selector == "single"
+        #set $db_name = $msgf_input.d.display_name.replace(".fasta", "") + ".fasta"
+        #set $input_name = $msgf_input.s.display_name
+        ln -s '$msgf_input.s' '${input_name}' &&
+        ln -s '$msgf_input.d' '${db_name}' &&
+        #else if $msgf_input.intype_selector == "fractions"
+        #set $db_name = $msgf_input.db_spectra.reverse.display_name.replace(".fasta", "") + ".fasta"
+        #set $input_name = $msgf_input.db_spectra.forward.display_name
+        ln -s '$msgf_input.db_spectra.forward' '${input_name}' &&
+        ln -s '$msgf_input.db_spectra.reverse' '${db_name}' &&
+        #end if
         #set $output_name = $input_name.replace(".mzML", "") + ".mzid"
-        ln -s '$s' '${input_name}' &&
-        ln -s '$d' '${db_name}' &&
 
         echo \\#Mods > Mods.txt &&
         #set $common_mods = str($common_fixed_modifications) + "," + str($common_variable_modifications)
@@ -56,6 +63,20 @@
 ]]>
     </command>
     <inputs>
+        <conditional name="msgf_input">
+          <param name="intype_selector" type="select" label="Type of MSGF+ analysis">
+            <option value="single">Single database</option>
+            <option value="fractions">Prefractionated database</option>
+          </param>
+          <when value="single">
+            <param argument="-s" type="data" format="mzml" label="Input Raw MS File(s)"/>
+            <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
+          </when>
+          <when value="fractions">
+		  <param name="db_spectra" type="data_collection" collection_type="paired" 
+			  label="Collection: Pairs of FASTA database (forward) and spectra (reverse)"/>
+          </when>
+        </conditional>
         <param argument="-s" type="data" format="mzml" label="Input Raw MS File(s)"/>
         <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
         <param argument="-tda" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Search with on-the-fly decoy database?" help="MSGF+ uses XXX_ as an accession prefix to indicate a decoy hit" />
@@ -203,8 +224,9 @@
     </outputs>
     <tests>
         <test>
-            <param name="s" value="input/201208-378803.mzML" />
-            <param name="d" value="input/cow.protein.PRG2012-subset.fasta" />
+	    <param name="msgf_input.intype_selector" value="single" />
+            <param name="msgf_input.s" value="input/201208-378803.mzML" />
+            <param name="msgf_input.d" value="input/cow.protein.PRG2012-subset.fasta" />
             <param name="tda" value="1" />
             <param name="ntt" value="1" />
             <param name="t" value="50" />
@@ -214,8 +236,21 @@
             <output name="output" file="201208-378803-msgf-50ppm-semitryptic-no_mods.mzid" lines_diff="6" />
         </test>
         <test>
-            <param name="s" value="input/201208-378803.mzML" />
-            <param name="d" value="input/cow.protein.PRG2012-subset.fasta" />
+	    <param name="msgf_input.intype_selector" value="fractions" />
+            <param name="msgf_input.db_spectra.forward" value="input/201208-378803.mzML" />
+            <param name="msgf_input.db_spectra.reverse" value="input/cow.protein.PRG2012-subset.fasta" />
+            <param name="tda" value="1" />
+            <param name="ntt" value="1" />
+            <param name="t" value="50" />
+            <param name="precursor_ion_tol_units" value="ppm" />            
+            <param name="common_fixed_modifications" value="" />
+            <param name="common_variable_modifications" value="" />
+            <output name="output" file="201208-378803-msgf-50ppm-semitryptic-no_mods.mzid" lines_diff="6" />
+        </test>
+        <test>
+	    <param name="msgf_input.intype_selector" value="single" />
+            <param name="msgf_input.s" value="input/201208-378803.mzML" />
+            <param name="msgf_input.d" value="input/cow.protein.PRG2012-subset.fasta" />
             <param name="tda" value="1" />
             <param name="t" value="0.02" />
             <param name="precursor_ion_tol_units" value="Da" />

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -77,8 +77,6 @@
 			  label="Collection: Pairs of FASTA database (forward) and spectra (reverse)"/>
           </when>
         </conditional>
-        <param argument="-s" type="data" format="mzml" label="Input Raw MS File(s)"/>
-        <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
         <param argument="-tda" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Search with on-the-fly decoy database?" help="MSGF+ uses XXX_ as an accession prefix to indicate a decoy hit" />
         <param argument="-t" type="float" value="10" label="Precursor mass tolerance" help="Error tolerance for matching peptide mass to precursor ion mass"/>
         <param name="precursor_ion_tol_units" type="select" label="Precursor mass tolerance units" help="Daltons are common for low-res instruments, ppm for high-res instruments">


### PR DESCRIPTION
Hi, our lab does quite a bit of MSGF+ searches using prefractionated databases matched with prefractionated spectra (by isoelectric point). We use our own MSGF+ tool XML but it would be nice if this could be in the toolshed instead. The tool takes as input either a spectra and a fasta dataset, or a dataset_collection of a pair of spectra/fasta.

There are 2 problems with this PR:
 + Breaks workflows/automation by moving the `params` inside a `conditional`
 + I cannot get the planemo tests to work (but the tool works inside galaxy)