### PR TITLE
searchgui sanitize input display names

### DIFF
--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -30,7 +30,7 @@
         echo "searchgui.version=@SEARCHGUI_VERSION@" >> searchgui.properties;
 
         #for $mgf in $peak_lists:
-            #set $input_name = $mgf.display_name.replace(".mgf", "") + ".mgf"
+            #set $input_name = $mgf.display_name.split('/')[-1].replace(".mgf", "") + ".mgf"
             ln -s -f '${mgf}' '${input_name}';
             #set $encoded_id = $__app__.security.encode_id($mgf.id)
             echo "Spectrums:${mgf.display_name}(API:${encoded_id}) ";


### PR DESCRIPTION
symbolic links to mgf input files for searchgui can not look like a
file path.
Issue occurred when uploading mgf files via URL.