### PR TITLE
fixed incorrect parameter format for mzIdentML output

### DIFF
--- a/tools/bumbershoot/myrimatch/myrimatch.xml
+++ b/tools/bumbershoot/myrimatch/myrimatch.xml
@@ -13,7 +13,7 @@
     <command>
 <![CDATA[
         #set $db_name = $ProteinDatabase.display_name.replace(".fasta", "") + ".fasta"
-        #if $OutputFormat.value == "mzid"
+        #if $OutputFormat.value == "mzIdentML"
             #set $output_ext="mzid"
         #else
             #set $output_ext="pepXML"
@@ -75,7 +75,7 @@
           <param name="input" type="data" format="mzml,mzxml,mgf,ms2,mz5" label="Input Raw MS File(s)"/>
           <param argument="-OutputFormat" type="select" label="Output Type" help="The file format to use for results of the search.">
               <option value="pepXML">pepXML</option>
-              <option value="mzid">mzIdentML</option>
+              <option value="mzIdentML">mzIdentML</option>
           </param>
           <param argument="-ProteinDatabase" format="fasta" type="data" label="Protein Database" help="The FASTA protein database to search against. Only amino-acid type FASTA is supported." />
           <param argument="-DecoyPrefix" type="text" label="Decoy Prefix" value="rev_" help="If the protein database contains accessions prefixed with this string, those proteins will be considered decoys. If there are no decoy protein, this prefix will be used to generate an automatic decoy for each target protein. Set this to an empty string to disable automatic decoys." />
@@ -181,7 +181,7 @@
     <outputs>
         <data format="raw_pepxml" name="output" from_work_dir="output">
             <change_format>
-                <when input="OutputFormat" value="mzid" format="mzid" />
+                <when input="OutputFormat" value="mzIdentML" format="mzid" />
             </change_format>
         </data>
     </outputs>

--- a/tools/bumbershoot/myrimatch/myrimatch.xml
+++ b/tools/bumbershoot/myrimatch/myrimatch.xml
@@ -207,14 +207,7 @@
             <param name="MaxResultRank" value="3" />
             <param name="MonoisotopeAdjustmentSet" value="[-1,2]" />
             <param name="UseSmartPlusThreeModel" value="false" />
-            <output name="output" file="201208-378803-mm.pepXML" compare="sim_size" delta="200000">
-                <assert_contents>
-                    <!-- currently broken in Galaxy, re-enable when fixed
-                    <is_valid_xml />
-                    -->
-                    <has_line line="&lt;/msms_pipeline_analysis&gt;" />
-                </assert_contents>
-            </output>
+            <output name="output" file="201208-378803-mm.pepXML" lines_diff="12" />
         </test>
         <test>
             <param name="input" value="input/201208-378803.mzML" />
@@ -228,14 +221,7 @@
             <param name="NumChargeStates" value="3" />
             <param name="MaxResultRank" value="1" />
             <param name="MonoisotopeAdjustmentSet" value="0" />
-            <output name="output" file="201208-378803-mm-15ppm-fully-tryptic.pepXML" compare="sim_size" delta="5000">
-                <assert_contents>
-                    <!-- currently broken in Galaxy, re-enable when fixed
-                    <is_valid_xml />
-                    -->
-                    <has_line line="&lt;/msms_pipeline_analysis&gt;" />
-                </assert_contents>
-            </output>
+            <output name="output" file="201208-378803-mm-15ppm-fully-tryptic.pepXML" lines_diff="12" />
         </test>
     </tests>
     <help>

--- a/tools/bumbershoot/myrimatch/myrimatch.xml
+++ b/tools/bumbershoot/myrimatch/myrimatch.xml
@@ -207,7 +207,7 @@
             <param name="MaxResultRank" value="3" />
             <param name="MonoisotopeAdjustmentSet" value="[-1,2]" />
             <param name="UseSmartPlusThreeModel" value="false" />
-            <output name="output" file="201208-378803-mm.pepXML" lines_diff="12" />
+            <output name="output" file="201208-378803-mm.pepXML" lines_diff="14" />
         </test>
         <test>
             <param name="input" value="input/201208-378803.mzML" />
@@ -221,7 +221,7 @@
             <param name="NumChargeStates" value="3" />
             <param name="MaxResultRank" value="1" />
             <param name="MonoisotopeAdjustmentSet" value="0" />
-            <output name="output" file="201208-378803-mm-15ppm-fully-tryptic.pepXML" lines_diff="12" />
+            <output name="output" file="201208-378803-mm-15ppm-fully-tryptic.pepXML" lines_diff="14" />
         </test>
     </tests>
     <help>

--- a/tools/bumbershoot/myrimatch/myrimatch.xml
+++ b/tools/bumbershoot/myrimatch/myrimatch.xml
@@ -207,7 +207,14 @@
             <param name="MaxResultRank" value="3" />
             <param name="MonoisotopeAdjustmentSet" value="[-1,2]" />
             <param name="UseSmartPlusThreeModel" value="false" />
-            <output name="output" file="201208-378803-mm.pepXML" lines_diff="12" />
+            <output name="output" file="201208-378803-mm.pepXML" compare="sim_size" delta="200000">
+                <assert_contents>
+                    <!-- currently broken in Galaxy, re-enable when fixed
+                    <is_valid_xml />
+                    -->
+                    <has_line line="&lt;/msms_pipeline_analysis&gt;" />
+                </assert_contents>
+            </output>
         </test>
         <test>
             <param name="input" value="input/201208-378803.mzML" />
@@ -221,7 +228,14 @@
             <param name="NumChargeStates" value="3" />
             <param name="MaxResultRank" value="1" />
             <param name="MonoisotopeAdjustmentSet" value="0" />
-            <output name="output" file="201208-378803-mm-15ppm-fully-tryptic.pepXML" lines_diff="12" />
+            <output name="output" file="201208-378803-mm-15ppm-fully-tryptic.pepXML" compare="sim_size" delta="5000">
+                <assert_contents>
+                    <!-- currently broken in Galaxy, re-enable when fixed
+                    <is_valid_xml />
+                    -->
+                    <has_line line="&lt;/msms_pipeline_analysis&gt;" />
+                </assert_contents>
+            </output>
         </test>
     </tests>
     <help>

--- a/tools/bumbershoot/myrimatch/myrimatch.xml
+++ b/tools/bumbershoot/myrimatch/myrimatch.xml
@@ -55,7 +55,6 @@
         #end if
         -FragmentMzTolerance '${tolerance_options.FragmentMzTolerance}${tolerance_options.fragment_mz_tolerance_units}'
         -UseSmartPlusThreeModel $advanced.UseSmartPlusThreeModel
-        -SpectrumListFilters '${advanced.SpectrumListFilters}'
         -MinPeptideLength $advanced.MinPeptideLength
         -MaxPeptideLength $advanced.MaxPeptideLength
         -NumChargeStates $advanced.NumChargeStates
@@ -169,7 +168,6 @@
                       <param argument="-FragmentationRule" type="text" label="Fragmentation Rule" help="Specify as a comma-separated list of a, b, c, x, y, z, or z* (z+1), e.g. 'b,y,z'" />
                   </when>
               </conditional>
-              <param argument="-SpectrumListFilters" type="text" value="peakPicking true 2-" label="Spectrum Filters" help="Spectral filters to apply. The default applies centroiding (either vendor or proteowizard, depending on platform)" />
               <param argument="-MinPeptideLength" type="integer" min="3" value="5" label="Minimum Peptide Length" help="Candidate peptides shorter than this will not be compared against any spectrum." />
               <param argument="-MaxPeptideLength" type="integer" min="3" value="75" label="Maximum Peptide Length" help="Candidate peptides longer than this will not be compared against any spectrum." />
               <param argument="-UseSmartPlusThreeModel" type="boolean" truevalue="true" falsevalue="false" label="Use Smart Plus 3 Model" help="For +3 and higher precursors, the fragment ions predicted depend on the way this parameter is set. When this parameter is true, then for each peptide bond, an internal calculation is done to estimate the basicity of the b and y fragment sequence. When this parameter is false, however, ALL possible charge distributions for the fragment ions are generated for every peptide bond." checked="true" />


### PR DESCRIPTION
Calling as -OutputFormat 'mzid' throws an error (should be 'mzIdentML')