### PR TITLE
tweaked Travis config to not try Galaxy upload for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,9 @@ script:
 
 after_success:
   - |
-    if [ "$TRAVIS_PULL_REQUEST" == "false" -a "$TRAVIS_BRANCH" == "master" ]; then
+
+    if [[ "$TRAVIS_PULL_REQUEST" == "false" && "$TRAVIS_BRANCH" == "master"
+        && "$TRAVIS_REPO_SLUG" == "galaxyproteomics/tools-galaxyp" ]]; then
       while read -r DIR; do planemo shed_update --shed_target testtoolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
       while read -r DIR; do planemo shed_update --shed_target toolshed --shed_email "$SHED_EMAIL" --shed_password "$SHED_PASSWORD" --force_repository_creation "$DIR" || exit 1; done < changed_repositories_chunk.list
     fi


### PR DESCRIPTION
The last step in the Travis CI config automatically tries to update the Galaxy TS if a build passes, but this isn't possible for forked repos and results in a failed build. This complicates testing of bug fixes, etc prior to submitting a PR.

This PR adds an additional check to make sure the build is under the main repo before trying the Galaxy update. Obviously I can't check that it works for you -- just that it prevents CI failure in my fork.