### PR TITLE
Future proofed hardklor/kronik to datatypes name change from short to…

### DIFF
--- a/tools/hardklor/datatypes_conf.xml
+++ b/tools/hardklor/datatypes_conf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <datatypes>
   <registration>
-    <datatype extension="hk" type="galaxy.datatypes.tabular:Tabular" subclass="true" />
-    <datatype extension="kr" type="galaxy.datatypes.tabular:Tabular" subclass="true" />
+    <datatype extension="hardklor" type="galaxy.datatypes.tabular:Tabular" subclass="true" />
+    <datatype extension="kronik" type="galaxy.datatypes.tabular:Tabular" subclass="true" />
   </registration>
 </datatypes>

--- a/tools/hardklor/hardklor.xml
+++ b/tools/hardklor/hardklor.xml
@@ -57,7 +57,7 @@ help="Max number of overlapping features in any mz window. Keep as low as necess
     </inputs>
     
     <outputs>
-        <data format="hk" name="output" />
+        <data format="hardklor" name="output" />
     </outputs>
     <tests>
         <test>

--- a/tools/hardklor/kronik.xml
+++ b/tools/hardklor/kronik.xml
@@ -8,7 +8,7 @@
     </stdio>
     <command>kronik -c $c -d $d -g $g -m $m -n $n -p $p "$inputfile" "$output"</command>
     <inputs>
-        <param name="inputfile" type="data" format="hk" label="Hardklör isotope distributions" />
+        <param name="inputfile" type="data" format="hardklor" label="Hardklör isotope distributions" />
         <param name="c" type="integer" value="5" label="Contaminant threshold in minutes" help="Peptides persisting for longer than this value are excluded" />
         <param name="d" type="integer" value="3" label="Match tolerance" help="Minimum consecutive scans peptide must be found in" />
         <param name="g" type="integer" value="1" label="Gap tolerance" help="Maximum amount of scans a peptide can skip to be considered in results" />
@@ -17,7 +17,7 @@
         <param name="p" type="integer" value="10" label="Mass accuracy (ppm)" help="Peptides in adjacent scans must differ by less than this value to be called the same." />
     </inputs>
     <outputs>
-        <data format="kr" name="output" />
+        <data format="kronik" name="output" />
     </outputs>
     <tests>
         <test>


### PR DESCRIPTION
… more descriptive

Only changed the datatypes. Future work would be to remove the datatypes_conf.xml file but only after the datatypes have landed in a galaxy core release (17.05 probably).