### PR TITLE
Bugfix for openMS

### DIFF
--- a/tools/openms/ITRAQAnalyzer.xml
+++ b/tools/openms/ITRAQAnalyzer.xml
@@ -31,7 +31,7 @@
   -id_pool     "$param_id_pool"
 #end if
 #if $param_algorithm_Extraction_select_activation:
-  -algorithm:Extraction:select_activation $param_algorithm_Extraction_select_activation
+  -algorithm:Extraction:select_activation '$param_algorithm_Extraction_select_activation'
 #end if
 #if $param_algorithm_Extraction_reporter_mass_shift:
   -algorithm:Extraction:reporter_mass_shift $param_algorithm_Extraction_reporter_mass_shift

--- a/tools/openms/IsobaricAnalyzer.xml
+++ b/tools/openms/IsobaricAnalyzer.xml
@@ -25,7 +25,7 @@
   -id_pool     "$param_id_pool"
 #end if
 #if $param_extraction_select_activation:
-  -extraction:select_activation $param_extraction_select_activation
+  -extraction:select_activation '$param_extraction_select_activation'
 #end if
 #if $param_extraction_reporter_mass_shift:
   -extraction:reporter_mass_shift $param_extraction_reporter_mass_shift

--- a/tools/openms/TMTAnalyzer.xml
+++ b/tools/openms/TMTAnalyzer.xml
@@ -28,7 +28,7 @@
   -id_pool     "$param_id_pool"
 #end if
 #if $param_algorithm_Extraction_select_activation:
-  -algorithm:Extraction:select_activation $param_algorithm_Extraction_select_activation
+  -algorithm:Extraction:select_activation '$param_algorithm_Extraction_select_activation'
 #end if
 #if $param_algorithm_Extraction_reporter_mass_shift:
   -algorithm:Extraction:reporter_mass_shift $param_algorithm_Extraction_reporter_mass_shift


### PR DESCRIPTION
Added quote marks to activation methods in tool cheetah since this contains values with whitespace in almost all options. Without this, the tool crashes.