### PR TITLE
Fix IDFileConverter

### DIFF
--- a/tools/openms/IDFileConverter.xml
+++ b/tools/openms/IDFileConverter.xml
@@ -10,50 +10,59 @@
   <expand macro="references"/>
   <expand macro="stdio"/>
   <expand macro="requirements"/>
-  <command>IDFileConverter
+  <command><![CDATA[
+   
+  ## check input file type
+  #set $in_type = $param_in.ext
 
-#if $param_in:
-  -in $param_in
-#end if
-#if $param_out:
-  -out $param_out
-#end if
-#if $param_out_type:
-  -out_type
-  #if " " in str($param_out_type):
-    "$param_out_type"
-  #else
-    $param_out_type
+  ## create the symlinks to set the proper file extension, since IDFileConverter uses them to choose how to handle the input files
+  ln -s '$param_in' 'param_in.${in_type}' &&
+  
+  IDFileConverter
+
+  #if $param_in:
+    -in 'param_in.${in_type}'
   #end if
-#end if
-#if $param_mz_file:
-  -mz_file $param_mz_file
-#end if
-#if $param_mz_name:
-  -mz_name     "$param_mz_name"
-#end if
-#if $param_peptideprophet_analyzed:
-  -peptideprophet_analyzed
-#end if
-#if $param_score_type:
-  -score_type
-  #if " " in str($param_score_type):
-    "$param_score_type"
-  #else
-    $param_score_type
+  #if $param_out:
+    -out $param_out
   #end if
-#end if
-#if $adv_opts.adv_opts_selector=='advanced':
-    #if $adv_opts.param_ignore_proteins_per_peptide:
-  -ignore_proteins_per_peptide
-#end if
-    #if $adv_opts.param_scan_regex:
-  -scan_regex     "$adv_opts.param_scan_regex"
-#end if
-    #if $adv_opts.param_force:
-  -force
-#end if
-#end if
+  #if $param_out_type:
+    -out_type
+    #if " " in str($param_out_type):
+      "$param_out_type"
+    #else
+      $param_out_type
+    #end if
+  #end if
+  #if $param_mz_file:
+    -mz_file $param_mz_file
+  #end if
+  #if $param_mz_name:
+    -mz_name     "$param_mz_name"
+  #end if
+  #if $param_peptideprophet_analyzed:
+    -peptideprophet_analyzed
+  #end if
+  #if $param_score_type:
+    -score_type
+    #if " " in str($param_score_type):
+      "$param_score_type"
+    #else
+      $param_score_type
+    #end if
+  #end if
+  #if $adv_opts.adv_opts_selector=='advanced':
+      #if $adv_opts.param_ignore_proteins_per_peptide:
+    -ignore_proteins_per_peptide
+  #end if
+      #if $adv_opts.param_scan_regex:
+    -scan_regex     "$adv_opts.param_scan_regex"
+  #end if
+      #if $adv_opts.param_force:
+    -force
+  #end if
+  #end if
+ ]]>
 </command>
   <inputs>
     <param name="param_in" type="data" format="tabular,mzid,pepxml,idxml" optional="False" label="Input file or directory containing the data to convert" help="(-in) This may be: &lt;br&gt;- a single file in a multi-purpose XML format (pepXML, protXML, idXML, mzid), &lt;br&gt;- a single file in a search engine-specific format (Mascot: mascotXML, OMSSA: omssaXML, X! Tandem: xml, Percolator: psms), &lt;br&gt;- a single text file (tab separated) with one line for all peptide sequences matching a spectrum (top N hits), &lt;br&gt;- for Sequest results, a directory containing .out files. &lt;br&gt;"/>
@@ -92,7 +101,7 @@
     </expand>
   </inputs>
   <outputs>
-    <data name="param_out" format="mzid"/>
+    <data name="param_out" auto_format="true"/>
   </outputs>
   <help>Converts identification engine file formats.
 

--- a/tools/openms/readme.md
+++ b/tools/openms/readme.md
@@ -102,10 +102,32 @@ Generating OpenMS wrappers
     [...]
     ]]>
     ```
-
- * In `FileConverter.xml` add `auto_format="true"` to the output, e.g.:
+    
+ * In `IDFileConverter.xml` the following is needed in the command section at the beginning (check your file to know what to copy where):
  
-        <data name="param_out" metadata_source="param_in" auto_format="true"/>
+   ```
+    <command><![CDATA[
+   
+      ## check input file type
+      #set $in_type = $param_in.ext
+
+      ## create the symlinks to set the proper file extension, since IDFileConverter uses them to choose how to handle the input files
+      ln -s '$param_in' 'param_in.${in_type}' &&
+
+      IDFileConverter
+
+      #if $param_in:
+        -in 'param_in.${in_type}'
+      #end if
+
+        [...]
+        ]]>
+    ```
+
+ * In `IDFileConverter.xml` and `FileConverter.xml` add `auto_format="true"` to the output, e.g.:
+ 
+   - `<data name="param_out" auto_format="true"/>`
+   - `<data name="param_out" metadata_source="param_in" auto_format="true"/>`
         
  * To add an example test case to `DecoyDatabase.xml` add the following after the output section. If standard settings change you might have to adjust the options and/or the test files.
  


### PR DESCRIPTION
Unfortunately, IDFileConverter detects the input type according to the file extension, which is not working with Galaxy. This is a work around which should work in common cases (e.g. mzid, idxml).