### PR TITLE
peptideshaker - Add ppm option, 2017_04_01 release

### DIFF
--- a/tools/peptideshaker/macros.xml
+++ b/tools/peptideshaker/macros.xml
@@ -49,7 +49,7 @@
 
     </token>
     <token name="@SEARCHGUI_MAJOR_VERSION@">3</token>
-    <token name="@SEARCHGUI_VERSION@">3.2.11</token>
+    <token name="@SEARCHGUI_VERSION@">3.2.13</token>
     <xml name="general_options">
 
         <section name="protein_digest_options" expanded="false" title="Protein Digestion Options">

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -1,4 +1,4 @@
-<tool id="peptide_shaker" name="Peptide Shaker" version="1.16.3">
+<tool id="peptide_shaker" name="Peptide Shaker" version="1.16.4">
     <description>
         Perform protein identification using various search engines based on results from SearchGUI
     </description>
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="1.16.3">peptide-shaker</requirement>
+        <requirement type="package" version="1.16.4">peptide-shaker</requirement>
     </requirements>
     <expand macro="stdio" />
     <command>
@@ -51,8 +51,9 @@
                         -ptm_threshold "${processing_options.ptm_score.ptm_threshold}"
                     #end if
                 #end if
-                -protein_fraction_mw_confidence "${processing_options.protein_fraction_mw_confidence}"
                 -ptm_alignment "${processing_options.ptm_alignment}"
+                -ptm_sequence_matching_type "${processing_options.ptm_sequence_matching_type}"
+                -protein_fraction_mw_confidence "${processing_options.protein_fraction_mw_confidence}"
             #end if
 
            ##Optional filtering parameters:
@@ -205,6 +206,7 @@
                     <param name="ptm_score_selector" type="select" label="The PTM probabilistic score to use for PTM localization">
                         <option value="0" selected="True">A-score</option>
                         <option value="1">PhosphoRS</option>
+                        <option value="2">None</option>
                     </param>
                     <when value="0" />
                     <when value="1">
@@ -212,7 +214,13 @@
                         <param name="ptm_threshold" label="The threshold to use for the PTM scores" optional="true" value="" type="float"
                             help="Automatic mode will be used if not set" />
                     </when>
+                    <when value="2" />
                 </conditional>
+                <param name="ptm_sequence_matching_type" type="select" label="The PTM to peptide sequence matching type">
+                     <option value="0">Character Sequence</option>
+                     <option value="1" selected="true">Amino Acids</option>
+                     <option value="2">Indistinguishable Amino Acids</option>
+                </param>
                 <param name="ptm_alignment" label="Align peptide ambiguously localized PTMs on confident sites" type="boolean" truevalue="1" falsevalue="0" checked="true"/>
                 <!-- SKIPPING -protein_fraction_mw_confidence ${processing_options.protein_fraction_mw_confidence} -->
             </when>


### PR DESCRIPTION
Target 2017_04_01 release:
  SearchGui:3.2.13
  PeptideShaker:1.16.4
Add  -ptm_score None
Add  -ptm_sequence_matching_type