### PR TITLE
Allow dash/hyphen/minus in a filename

### DIFF
--- a/tools/percolator/nested_collection.xml
+++ b/tools/percolator/nested_collection.xml
@@ -1,4 +1,4 @@
-<tool id="batched_set_list_creator" name="Create nested list" version="3.2">
+<tool id="batched_set_list_creator" name="Create nested list" version="3.3">
     <description>based on filenames and batch sizes</description>
     <stdio>
         <exit_code range="1:" />
@@ -96,7 +96,7 @@
             <param name="filetype" value="tabular" />
             <param name="listtobatch">
                 <collection type="list">
-                    <element name="fr_one_set1_spectra" value="empty_file1.mzid"/>
+                    <element name="fr_one_set1-spectra" value="empty_file1.mzid"/>
                     <element name="fr_two_set1_spectra" value="empty_file2.mzid"/>
                     <element name="fr_three_set1_spectra" value="empty_file3.mzid"/>
                     <element name="fr_four_set1_spectra" value="empty_file4.mzid"/>
@@ -114,7 +114,7 @@
             </param>
             <output_collection name="batched_fractions_tab" type="list:list">
                 <element name="set1_batch0">
-                    <element name="inputfn00_fr_one_set1_spectra" ftype="tabular" file="empty_file1.mzid"/>
+                    <element name="inputfn00_fr_one_set1-spectra" ftype="tabular" file="empty_file1.mzid"/>
                     <element name="inputfn01_fr_two_set1_spectra" ftype="tabular" file="empty_file2.mzid"/>
                     <element name="inputfn02_fr_three_set1_spectra" ftype="tabular" file="empty_file3.mzid"/>
                     <element name="inputfn03_fr_four_set1_spectra" ftype="tabular" file="empty_file4.mzid"/>

--- a/tools/percolator/nested_collection.xml
+++ b/tools/percolator/nested_collection.xml
@@ -38,15 +38,15 @@
     <outputs>
         <collection name="batched_fractions_mzid" type="list:list" label="Pooled batched mzIdentML data">
           <filter>filetype == "mzid"</filter>
-          <discover_datasets pattern="(?P&lt;identifier_0&gt;\w+[^_][^_][^_])___(?P&lt;identifier_1&gt;[\w.]+)\.data" ext="mzid" visible="false" />
+          <discover_datasets pattern="(?P&lt;identifier_0&gt;\w+[^_][^_][^_])___(?P&lt;identifier_1&gt;[\w.-]+)\.data" ext="mzid" visible="false" />
         </collection>
         <collection name="batched_fractions_perco" type="list:list" label="Pooled batched percolator data">
           <filter>filetype == "percout"</filter>
-          <discover_datasets pattern="(?P&lt;identifier_0&gt;\w+[^_][^_][^_])___(?P&lt;identifier_1&gt;[\w.]+)\.data" ext="percout" visible="false" />
+          <discover_datasets pattern="(?P&lt;identifier_0&gt;\w+[^_][^_][^_])___(?P&lt;identifier_1&gt;[\w.-]+)\.data" ext="percout" visible="false" />
         </collection>
         <collection name="batched_fractions_tab" type="list:list" label="Pooled batched tabular data">
           <filter>filetype == "tabular"</filter>
-          <discover_datasets pattern="(?P&lt;identifier_0&gt;\w+[^_][^_][^_])___(?P&lt;identifier_1&gt;[\w.]+)\.data" ext="tabular" visible="false" />
+          <discover_datasets pattern="(?P&lt;identifier_0&gt;\w+[^_][^_][^_])___(?P&lt;identifier_1&gt;[\w.-]+)\.data" ext="tabular" visible="false" />
         </collection>
     </outputs>
     <tests>


### PR DESCRIPTION
Nested collection creator has a regex to get nested list identifiers. Except that regex doesnt like names with characters other than `[\w.]`, or in other words `[a-zA-Z0-9_.]`. Typically filenames are used, and I added here the `-` hyphen/dash/minus character which is not uncommon and allowed in filenames.

If you can think of any other character which may show up in a filename, please tell or commit.