### PR TITLE
Hirieftools multi-IPG strip and column patterns

### DIFF
--- a/tools/pi_db_tools/README.rst
+++ b/tools/pi_db_tools/README.rst
@@ -1,4 +1,4 @@
-GalaxyP - Percolator
+GalaxyP - HiRIEF tools
 =======================
 
 - Home: <https://github.com/galaxyproteomics/tools-galaxyp/>

--- a/tools/pi_db_tools/delta_pi_calc.xml
+++ b/tools/pi_db_tools/delta_pi_calc.xml
@@ -1,11 +1,25 @@
-<tool id="calc_delta_pi" name="Add delta pI" version="1.0">
+<tool id="calc_delta_pi" name="Add delta pI" version="1.1">
     <requirements>
         <requirement type="package" version="3.6">python</requirement>
     </requirements>
     <description>to peptide table</description>
     <command>
-	    python '$__tool_directory__/peptide_pi_annotator.py' -i '$trainingpi' -p '$peptable'
-            --stripcol $stripcol --pepcol $pepcol --fraccol $fraccol --out '$output'
+	    python '$__tool_directory__/peptide_pi_annotator.py' -i '$trainingpi' -p '$peptable' --out '$output'
+	    #if $stripcol
+	        --stripcol $stripcol
+	    #else if $stripcolpattern
+	        --stripcolpattern $stripcolpattern
+	    #end if
+	    #if $pepcol
+                --pepcol $pepcol 
+	    #else if $pepcolpattern
+                --pepcolpattern $pepcolpattern
+	    #end if
+	    #if $fraccol
+                --fraccol $fraccol
+	    #else if $fraccolpattern
+                --fraccolpattern $fraccolpattern
+	    #end if
 	    
 	    --strippatterns
 	    #for $strip in $strips
@@ -42,9 +56,12 @@
 	      </sanitizer>
           </param>
       </repeat>
-      <param name="pepcol" type="integer" value="" label="Peptide sequence column in peptide table" />
-      <param name="fraccol" type="integer" value="" label="Fraction number column in peptide table" />
-      <param name="stripcol" type="integer" value="" label="Strip pattern column in peptide table" help="E.g. column with filename to derive strip name from"/>
+      <param name="pepcolpattern" type="text" value="" optional="true" label="Peptide sequence pattern for column header field in peptide table." />
+      <param name="pepcol" type="integer" value="" optional="true" label="Peptide sequence column number in peptide table. First column is 1. Overrides column pattern." />
+      <param name="fraccolpattern" type="text" value="" optional="true" label="Fraction number column header papttern in peptide table." />
+      <param name="fraccol" type="integer" optional="true" value="" label="Fraction number column number in peptide table. First column is 1. Overrides column pattern." />
+      <param name="stripcolpattern" type="text" optional="true" value="" label="Strip pattern header column pattern in peptide table" help="E.g. column with filename to derive strip name from"/>
+      <param name="stripcol" type="integer" optional="true" value="" label="Strip pattern column number in peptide table" help="E.g. column with filename to derive strip name from. First column is 1. Overrides column pattern"/>
       <repeat name="strips" title="pI separation strip data">
 	      <param name="pattern" type="text" label="Strip regex detection pattern" help="Regex (see help below) that identifies the pI strip from the column in the above field.">
                   <sanitizer>
@@ -71,6 +88,27 @@
             <param name="pepcol" value="1" />
             <param name="fraccol" value="4" />
             <param name="stripcol" value="2" />
+            <repeat name="strips">
+                <param name="pattern" value="strip1" />
+                <param name="intercept" value="8.21" />
+                <param name="fr_width" value="0.013" />
+            </repeat>
+            <repeat name="strips">
+                <param name="pattern" value="strip2" />
+                <param name="intercept" value="6.11" />
+                <param name="fr_width" value="0.04" />
+            </repeat>
+            <output name="output" value="peptable_deltapi.txt" />
+        </test>
+        <test> 
+            <param name="trainingpi" value="predicted_peptides.txt" />
+            <param name="peptable" value="peptable.txt" />
+            <repeat name="ignoremods">
+                <param name="regex" value="*" />
+            </repeat>
+            <param name="pepcolpattern" value="Sequence" />
+            <param name="fraccolpattern" value="Fraction" />
+            <param name="stripcolpattern" value="Filename" />
             <repeat name="strips">
                 <param name="pattern" value="strip1" />
                 <param name="intercept" value="8.21" />

--- a/tools/pi_db_tools/delta_pi_calc.xml
+++ b/tools/pi_db_tools/delta_pi_calc.xml
@@ -8,17 +8,17 @@
 	    #if $stripcol
 	        --stripcol $stripcol
 	    #else if $stripcolpattern
-	        --stripcolpattern $stripcolpattern
+	        --stripcolpattern '$stripcolpattern'
 	    #end if
 	    #if $pepcol
                 --pepcol $pepcol 
 	    #else if $pepcolpattern
-                --pepcolpattern $pepcolpattern
+                --pepcolpattern '$pepcolpattern'
 	    #end if
 	    #if $fraccol
                 --fraccol $fraccol
 	    #else if $fraccolpattern
-                --fraccolpattern $fraccolpattern
+                --fraccolpattern '$fraccolpattern'
 	    #end if
 	    
 	    --strippatterns

--- a/tools/pi_db_tools/pi_db_split.xml
+++ b/tools/pi_db_tools/pi_db_split.xml
@@ -1,4 +1,4 @@
-<tool id="pi_db_split" name="Split peptide database" version="1.0">
+<tool id="pi_db_split" name="Split peptide database" version="1.1">
     <description>into pI separated fractions</description>
     <requirements>
         <requirement type="package">numpy</requirement>
@@ -8,10 +8,16 @@
 	    <![CDATA[
 	    mkdir pi_fr_out && cd pi_fr_out &&
 	    python '$__tool_directory__/pi_database_splitter.py' -i '$pipeptides' -p '$peptable'
-            --intercept $intercept --width $fr_width --tolerance $tolerance --amount $fr_amount --prefix pisplit
-	    --deltacol $deltacol --picutoff $picutoff 
+            --intercept $intercept --width $fr_width --tolerance $tolerance --amount $fr_amount --prefix pisplit --picutoff $picutoff 
+	    #if $deltacol
+	        --deltacol $deltacol 
+            #else if $deltacolpattern
+		--deltacolpattern $deltacolpattern
+            #end if
 	    #if $fdrcol
 	        --fdrcol $fdrcol --fdrcutoff $fdrcutoff 
+            #else if $fdrcolpattern
+                --fdrcolpattern $fdrcolpattern --fdrcutoff $fdrcutoff 
 	    #end if
             #if $reverse
                 --reverse
@@ -26,9 +32,11 @@
     <inputs>
       <param name="pipeptides" type="data" format="tabular" label="Target peptides with pI and accession" help="First col accession, second sequence, third pI" />
       <param name="peptable" type="data" format="tabular" label="Peptide table to determine pI shift from" help="Should have delta pI as a column" />
-      <param name="fdrcol" type="integer" value="" optional="true" label="FDR (q-value) column in peptide table" />
+      <param name="fdrcolpattern" type="text" optional="true" label="FDR (q-value) column pattern in peptide table" />
+      <param name="fdrcol" type="integer" value="" optional="true" label="FDR (q-value) column number in peptide table" help="Overrides column pattern if filled. First column is 1" />
       <param name="fdrcutoff" type="float" value="0.0" help="Not used when no FDR column specified" label="FDR value cutoff for inclusion in shift determination" />
-      <param name="deltacol" type="integer" value="" label="Delta pI column in peptide table" />
+      <param name="deltacolpattern" type="text" value="" label="Delta pI column pattern in peptide table" />
+      <param name="deltacol" type="integer" optional="true" value="" label="Delta pI column number in peptide table" help="Overrides column pattern if filled. First column is 1"/>
       <param name="picutoff" type="float" value="0.2" optional="true" label="delta-pI cutoff for inclusion in shift determination" />
       <param name="minlen" type="integer" value="8" label="Minimum length of peptide to include in split DB" />
       <param name="maxlen" type="integer" optional="true" value="" label="Max. length of peptide to include in split DB" />
@@ -54,6 +62,30 @@
 		    <param name="fdrcol" value="3" />
 		    <param name="fdrcutoff" value="0.2" />
 		    <param name="deltacol" value="-1" />
+		    <param name="picutoff" value="10" />
+		    <param name="minlen" value="8" />
+		    <param name="intercept" value="5.6" />
+		    <param name="fr_width" value="1.3" />
+		    <param name="tolerance" value="0.1" />
+		    <param name="fr_amount" value="3" />
+		    <param name="reverse" value="false" />
+		    <output_collection name="target_pi_db" type="list">
+			    <element name="fr1" value="target_splitdb_fr1.fasta" />
+			    <element name="fr2" value="target_splitdb_fr2.fasta" />
+			    <element name="fr3" value="target_splitdb_fr3.fasta" />
+		    </output_collection>
+		    <output_collection name="decoy_pi_db" type="list">
+			    <element name="fr1" value="decoy_splitdb_fr1.fasta" />
+			    <element name="fr2" value="decoy_splitdb_fr2.fasta" />
+			    <element name="fr3" value="decoy_splitdb_fr3.fasta" />
+		    </output_collection>
+	    </test>
+	    <test>
+		    <param name="pipeptides" value="predicted_peptides_to_split.txt" />
+		    <param name="peptable" value="peptable_deltapi.txt" />
+		    <param name="fdrcolpattern" value="FDR" />
+		    <param name="fdrcutoff" value="0.2" />
+		    <param name="deltacolpattern" value="Delta" />
 		    <param name="picutoff" value="10" />
 		    <param name="minlen" value="8" />
 		    <param name="intercept" value="5.6" />

--- a/tools/pi_db_tools/pi_db_split.xml
+++ b/tools/pi_db_tools/pi_db_split.xml
@@ -21,12 +21,12 @@
 	    #if $deltacol
 	        --deltacol $deltacol 
             #else if $deltacolpattern
-		--deltacolpattern $deltacolpattern
+		--deltacolpattern '$deltacolpattern'
             #end if
 	    #if $fdrcol
 	        --fdrcol $fdrcol --fdrcutoff $fdrcutoff 
             #else if $fdrcolpattern
-                --fdrcolpattern $fdrcolpattern --fdrcutoff $fdrcutoff 
+                --fdrcolpattern '$fdrcolpattern' --fdrcutoff $fdrcutoff 
 	    #end if
             #if $maxlen
                 --maxlen $maxlen

--- a/tools/pi_db_tools/pi_db_split.xml
+++ b/tools/pi_db_tools/pi_db_split.xml
@@ -8,7 +8,16 @@
 	    <![CDATA[
 	    mkdir pi_fr_out && cd pi_fr_out &&
 	    python '$__tool_directory__/pi_database_splitter.py' -i '$pipeptides' -p '$peptable'
-            --intercept $intercept --width $fr_width --tolerance $tolerance --amount $fr_amount --prefix pisplit --picutoff $picutoff 
+	    #for $strip in $strips
+	        #if not $strip.peptable_pattern or str($strip.peptable_pattern) in $peptable.element_identifier
+                    --intercept $strip.intercept --width $strip.fr_width --tolerance $strip.tolerance --amount $strip.fr_amount --prefix pisplit --picutoff $strip.picutoff 
+                    #if $strip.reverse
+                        --reverse
+                    #end if
+	            #break
+                #end if 
+            #end for
+
 	    #if $deltacol
 	        --deltacol $deltacol 
             #else if $deltacolpattern
@@ -19,9 +28,6 @@
             #else if $fdrcolpattern
                 --fdrcolpattern $fdrcolpattern --fdrcutoff $fdrcutoff 
 	    #end if
-            #if $reverse
-                --reverse
-            #end if
             #if $maxlen
                 --maxlen $maxlen
             #end if
@@ -37,14 +43,17 @@
       <param name="fdrcutoff" type="float" value="0.0" help="Not used when no FDR column specified" label="FDR value cutoff for inclusion in shift determination" />
       <param name="deltacolpattern" type="text" value="" label="Delta pI column pattern in peptide table" />
       <param name="deltacol" type="integer" optional="true" value="" label="Delta pI column number in peptide table" help="Overrides column pattern if filled. First column is 1"/>
-      <param name="picutoff" type="float" value="0.2" optional="true" label="delta-pI cutoff for inclusion in shift determination" />
       <param name="minlen" type="integer" value="8" label="Minimum length of peptide to include in split DB" />
       <param name="maxlen" type="integer" optional="true" value="" label="Max. length of peptide to include in split DB" />
-      <param name="intercept" type="float" value="" label="Intercept of pI strip" />
-      <param name="fr_width" type="float" value="" label="Fraction width" />
-      <param name="tolerance" type="float" value="" label="pI tolerance" />
-      <param name="fr_amount" type="integer" value="" label="Fraction amount" />
-      <param name="reverse" type="boolean" label="Strip is reversed (high-to-low pI)?" />
+      <repeat name="strips" title="pI separation strip data">
+          <param name="peptable_pattern" type="text" label="Pattern to find correct peptide table for a strip, for when multiple peptide tables have different strips" help="Will match against peptide table's name. Leave blank for single peptide table or when using same strip in all tables" />
+          <param name="intercept" type="float" value="" label="Intercept of pI strip" />
+          <param name="fr_width" type="float" value="" label="Fraction width" />
+          <param name="tolerance" type="float" value="" label="pI tolerance" />
+          <param name="fr_amount" type="integer" value="" label="Fraction amount" />
+          <param name="reverse" type="boolean" label="Strip is reversed (high-to-low pI)?" />
+          <param name="picutoff" type="float" value="0.2" optional="true" label="delta-pI cutoff for inclusion in shift determination" />
+      </repeat>
     </inputs>
     
     <outputs>
@@ -62,13 +71,16 @@
 		    <param name="fdrcol" value="3" />
 		    <param name="fdrcutoff" value="0.2" />
 		    <param name="deltacol" value="-1" />
-		    <param name="picutoff" value="10" />
 		    <param name="minlen" value="8" />
-		    <param name="intercept" value="5.6" />
-		    <param name="fr_width" value="1.3" />
-		    <param name="tolerance" value="0.1" />
-		    <param name="fr_amount" value="3" />
-		    <param name="reverse" value="false" />
+                    <repeat name="strips">
+		        <param name="peptable_pattern" value="deltapi" />
+		        <param name="intercept" value="5.6" />
+		        <param name="fr_width" value="1.3" />
+		        <param name="tolerance" value="0.1" />
+		        <param name="fr_amount" value="3" />
+		        <param name="reverse" value="false" />
+		        <param name="picutoff" value="10" />
+                    </repeat>
 		    <output_collection name="target_pi_db" type="list">
 			    <element name="fr1" value="target_splitdb_fr1.fasta" />
 			    <element name="fr2" value="target_splitdb_fr2.fasta" />
@@ -86,13 +98,15 @@
 		    <param name="fdrcolpattern" value="FDR" />
 		    <param name="fdrcutoff" value="0.2" />
 		    <param name="deltacolpattern" value="Delta" />
-		    <param name="picutoff" value="10" />
 		    <param name="minlen" value="8" />
-		    <param name="intercept" value="5.6" />
-		    <param name="fr_width" value="1.3" />
-		    <param name="tolerance" value="0.1" />
-		    <param name="fr_amount" value="3" />
-		    <param name="reverse" value="false" />
+                    <repeat name="strips">
+		        <param name="intercept" value="5.6" />
+		        <param name="fr_width" value="1.3" />
+		        <param name="tolerance" value="0.1" />
+		        <param name="fr_amount" value="3" />
+		        <param name="reverse" value="false" />
+		        <param name="picutoff" value="10" />
+                    </repeat>
 		    <output_collection name="target_pi_db" type="list">
 			    <element name="fr1" value="target_splitdb_fr1.fasta" />
 			    <element name="fr2" value="target_splitdb_fr2.fasta" />


### PR DESCRIPTION
This PR changes the interface to the pI (isoelectric point) based fractionation of databases and the calculation of delta pI for peptides. It makes possible:

- using columns by name-pattern, doing a simple `pattern in columnname` check, aside the column number input
- making possible using the db splitter with multiple IPG ranges as a repeat, when input peptide tables have different IPG ranges.