### PR TITLE
Small update to msgfplus

### DIFF
--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -24,7 +24,7 @@
         ln -s '$msgf_input.db_spectra.forward' '${input_name}' &&
         ln -s '$msgf_input.db_spectra.reverse' '${db_name}' &&
         #end if
-        #set $output_name = $input_name.replace(".mzML", "") + ".mzid"
+        #set $output_name = $input_name.replace(".mzML", ".mzid")
 
         echo \\#Mods > Mods.txt &&
         #set $common_mods = str($common_fixed_modifications) + "," + str($common_variable_modifications)

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -78,7 +78,7 @@
           </when>
           <when value="fractions">
 		  <param name="db_spectra" type="data_collection" collection_type="paired" 
-			  label="Collection: Pairs of FASTA database (forward) and spectra (reverse)"/>
+			  label="Collection: Pairs of spectra (forward) and FASTA database (reverse)"/>
           </when>
         </conditional>
         <param name="tsvcheck" type="boolean" label="Output TSV as well?" />

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -269,7 +269,7 @@
             <param name="precursor_ion_tol_units" value="ppm" />            
             <param name="common_fixed_modifications" value="" />
             <param name="common_variable_modifications" value="" />
-            <output name="output" file="201208-378803-msgf_20161026-50ppm-semitryptic-no_mods.mzid" compare="sim_size" delta="20" />
+            <output name="output" file="201208-378803-msgf_20161026-50ppm-semitryptic-no_mods.mzid" compare="sim_size" delta="100" />
         </test>
         <test>
             <param name="msgf_input|intype_selector" value="single" />

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -1,4 +1,4 @@
-<tool id="msgfplus" name="MS-GF+" version="0.1">
+<tool id="msgfplus" name="MS-GF+" version="0.2">
     <description>
         Identifies peptides in tandem mass spectra using the MS-GF+ search engine.
     </description>

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -14,13 +14,13 @@
 
 <![CDATA[
         #if $msgf_input.intype_selector == "single"
-        #set $db_name = $msgf_input.d.display_name.replace(".fasta", "") + ".fasta"
-        #set $input_name = $msgf_input.s.display_name
+        #set $db_name = $msgf_input.d.element_identifier.replace(".fasta", "") + ".fasta"
+        #set $input_name = $msgf_input.s.element_identifier.replace(".mzML", "") + ".mzML"
         ln -s '$msgf_input.s' '${input_name}' &&
         ln -s '$msgf_input.d' '${db_name}' &&
         #else if $msgf_input.intype_selector == "fractions"
-        #set $db_name = $msgf_input.db_spectra.reverse.display_name.replace(".fasta", "") + ".fasta"
-        #set $input_name = $msgf_input.db_spectra.forward.display_name
+        #set $db_name = $msgf_input.db_spectra.reverse.element_identifier.replace(".fasta", "") + ".fasta"
+        #set $input_name = $msgf_input.db_spectra.forward.element_identifier.replace(".mzML", "") + ".mzML"
         ln -s '$msgf_input.db_spectra.forward' '${input_name}' &&
         ln -s '$msgf_input.db_spectra.reverse' '${db_name}' &&
         #end if


### PR DESCRIPTION
This PR updates the msgfplus.xml tool.

1 - help text was wrong about forward and reverse input
2 - usage of `display_name` is not recommended, marius told me on gitter to use `element_identifier` mostly
3 - Add `.mzML` to the input file name because msgfplus crashes when the extension is wrong and sometimes element identifiers do not contain the mzML extension.
