### PR TITLE
Fix link to IDPicker website and remove my VU affiliation

### DIFF
--- a/tools/bumbershoot/idpassemble/README.md
+++ b/tools/bumbershoot/idpassemble/README.md
@@ -13,7 +13,7 @@ Bumbershoot idpAssemble, a part of Bumbershoot IDPicker.
 
 See:
 
-* <http://fenchurch.mc.vanderbilt.edu/>
+* <http://idpicker.org/>
 
 
 GalaxyP Community
@@ -48,7 +48,6 @@ Authors
 Authors and contributors:
 
 * Matt Chambers <matt.chambers42@gmail.com>
-  Vanderbilt University Medical Center
 
 * John Chilton <jmchilton@gmail.com>
   Minnesota Supercomputing Institute, University of Minnesota

--- a/tools/bumbershoot/idpqonvert/README.md
+++ b/tools/bumbershoot/idpqonvert/README.md
@@ -13,7 +13,7 @@ Bumbershoot idpQonvert, a part of Bumbershoot IDPicker.
 
 See:
 
-* <http://fenchurch.mc.vanderbilt.edu/>
+* <http://idpicker.org/>
 
 
 GalaxyP Community
@@ -48,7 +48,6 @@ Authors
 Authors and contributors:
 
 * Matt Chambers <matt.chambers42@gmail.com>
-  Vanderbilt University Medical Center
 
 * John Chilton <jmchilton@gmail.com>
   Minnesota Supercomputing Institute, University of Minnesota

--- a/tools/bumbershoot/idpquery/README.md
+++ b/tools/bumbershoot/idpquery/README.md
@@ -13,7 +13,7 @@ Bumbershoot idpQuery, a part of Bumbershoot IDPicker.
 
 See:
 
-* <http://fenchurch.mc.vanderbilt.edu/>
+* <http://idpicker.org/>
 
 
 GalaxyP Community
@@ -48,7 +48,6 @@ Authors
 Authors and contributors:
 
 * Matt Chambers <matt.chambers42@gmail.com>
-  Vanderbilt University Medical Center
 
 * John Chilton <jmchilton@gmail.com>
   Minnesota Supercomputing Institute, University of Minnesota

--- a/tools/bumbershoot/myrimatch/README.md
+++ b/tools/bumbershoot/myrimatch/README.md
@@ -13,7 +13,7 @@ Bumbershoot MyriMatch.
 
 See:
 
-* <http://fenchurch.mc.vanderbilt.edu/>
+* <https://www.ncbi.nlm.nih.gov/pubmed/17269722>
 
 
 GalaxyP Community
@@ -48,7 +48,6 @@ Authors
 Authors and contributors:
 
 * Matt Chambers <matt.chambers42@gmail.com>
-  Vanderbilt University Medical Center
 
 * John Chilton <jmchilton@gmail.com>
   Minnesota Supercomputing Institute, Univeristy of Minnesota


### PR DESCRIPTION
This should also get idpQuery into MTS. Not sure why idpQonvert and idpAssemble are there but not idpQuery.