### PR TITLE
Naming output of MSGFplus paired spectra/db better

### DIFF
--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -1,4 +1,4 @@
-<tool id="msgfplus" name="MS-GF+" version="0.2">
+<tool id="msgfplus" name="MS-GF+" version="0.3">
     <description>
         Identifies peptides in tandem mass spectra using the MS-GF+ search engine.
     </description>
@@ -20,7 +20,7 @@
         ln -s '$msgf_input.d' '${db_name}' &&
         #else if $msgf_input.intype_selector == "fractions"
         #set $db_name = $msgf_input.db_spectra.reverse.element_identifier.replace(".fasta", "") + ".fasta"
-        #set $input_name = $msgf_input.db_spectra.forward.element_identifier.replace(".mzML", "") + ".mzML"
+        #set $input_name = $msgf_input.db_spectra.name.replace(".mzML", "") + ".mzML"
         ln -s '$msgf_input.db_spectra.forward' '${input_name}' &&
         ln -s '$msgf_input.db_spectra.reverse' '${db_name}' &&
         #end if


### PR DESCRIPTION
The old output schema resulted in output named "forward.mzML" since that is the unchangeable name of the paired element that was the spectra dataset.

I changed to use the `name` attribute of the element containing the dataset pair, which results in proper spectra file names. I use `name` and not `element_identifier` since the element itself is a collection and will raise a KeyError if `element_identifier` is used.

A bit annoying this didnt end up in yesterdays PR.