### PR TITLE
(re)added zip as requirement of SearchGUI

### DIFF
--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -7,7 +7,7 @@
     </macros>
     <requirements>
 	<requirement type="package" version="@SEARCHGUI_VERSION@">searchgui</requirement>
-	<requirement type="package">zip</requirement>
+	<requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <expand macro="stdio" />
     <command>

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -6,7 +6,8 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="@SEARCHGUI_VERSION@">searchgui</requirement>
+	<requirement type="package" version="@SEARCHGUI_VERSION@">searchgui</requirement>
+	<requirement type="package">zip</requirement>
     </requirements>
     <expand macro="stdio" />
     <command>


### PR DESCRIPTION
SearchGUI needs `zip`, see: https://github.com/bernt-matthias/tools-galaxyp/blob/0a0c1b53f934a0edfc7f18e9c401ad353a44092a/tools/peptideshaker/searchgui.xml#L419. This has been added before: 

https://github.com/galaxyproteomics/tools-galaxyp/commit/87d3dffcc9ef41e1f7c8488d1939165056f19413#diff-ec5346afe3992b199241a92092c2e047

but unfortunately removed later

https://github.com/galaxyproteomics/tools-galaxyp/commit/a2bd191e342173a297b0d60caa09bd4826239ad5#diff-ec5346afe3992b199241a92092c2e047