### PR TITLE
Allow for multiple variable modifications in MSGFPlusAdapter

### DIFF
--- a/tools/openms/MSGFPlusAdapter.xml
+++ b/tools/openms/MSGFPlusAdapter.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--This is a configuration file for the integration of a tools into Galaxy (https://galaxyproject.org/). This file was automatically generated using CTD2Galaxy.-->
 <!--Proposed Tool Section: [Identification]-->
-<tool id="MSGFPlusAdapter" name="MSGFPlusAdapter" version="2.2.0">
+<tool id="MSGFPlusAdapter" name="MSGFPlusAdapter" version="2.2.0.1">
   <description>MS/MS database search using MS-GF+.</description>
   <macros>
     <token name="@EXECUTABLE@">MSGFPlusAdapter</token>

--- a/tools/openms/MSGFPlusAdapter.xml
+++ b/tools/openms/MSGFPlusAdapter.xml
@@ -2738,7 +2738,7 @@
         <option value="trifluoro (L)">trifluoro (L)</option>
       </param>
     </repeat>
-    <repeat name="rep_param_variable_modifications" min="0" max="1" title="param_variable_modifications">
+    <repeat name="rep_param_variable_modifications" min="0" title="param_variable_modifications">
       <param name="param_variable_modifications" type="select" optional="True" label="Variable modifications, specified using UniMod (www.unimod.org) terms," help="(-variable_modifications) e.g. 'Oxidation (M)'">
         <option value="15N-oxobutanoic (N-term C)">15N-oxobutanoic (N-term C)</option>
         <option value="2-dimethylsuccinyl (C)">2-dimethylsuccinyl (C)</option>

--- a/tools/openms/MSGFPlusAdapter.xml
+++ b/tools/openms/MSGFPlusAdapter.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--This is a configuration file for the integration of a tools into Galaxy (https://galaxyproject.org/). This file was automatically generated using CTD2Galaxy.-->
 <!--Proposed Tool Section: [Identification]-->
-<tool id="MSGFPlusAdapter" name="MSGFPlusAdapter" version="2.2.0.1">
+<tool id="MSGFPlusAdapter" name="MSGFPlusAdapter" version="2.2.0">
   <description>MS/MS database search using MS-GF+.</description>
   <macros>
     <token name="@EXECUTABLE@">MSGFPlusAdapter</token>


### PR DESCRIPTION
The wrapper for MSGFPlusAdapter allowed only one variable modification, although the tool can take an process several. 

This fix solves part of https://github.com/galaxyproteomics/tools-galaxyp/issues/209