### PR TITLE
Fixed Msgf custom modification with multiple aa_specificities

### DIFF
--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -1,4 +1,4 @@
-<tool id="msgfplus" name="MS-GF+" version="0.3">
+<tool id="msgfplus" name="MS-GF+" version="0.3.1">
     <description>
         Identifies peptides in tandem mass spectra using the MS-GF+ search engine.
     </description>
@@ -33,7 +33,8 @@
         #end for
 
         #for $mod in $custom_mods
-          echo '${mod.formula_or_mass},${mod.aa_specificity},${mod.fix_or_opt},${mod.position_specificity},${mod.mod_name}' >> Mods.txt &&
+        	#set aa_nocomma = str($mod.aa_specificity).replace(",", "")
+          echo '${mod.formula_or_mass},${aa_nocomma},${mod.fix_or_opt},${mod.position_specificity},${mod.mod_name}' >> Mods.txt &&
         #end for
 
 	msgf_plus
@@ -305,7 +306,7 @@
             <param name="custom_mods_1|fix_or_opt" value="opt" />
             <param name="custom_mods_1|position_specificity" value="any" />
             <param name="custom_mods_1|mod_name" value="cGMP" />
-
+            
             <output name="output" file="201208-378803-msgf_20161026-2mmu-tryptic-many_mods.mzid" lines_diff="6" />
         </test>
     </tests>

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -37,7 +37,7 @@
           echo '${mod.formula_or_mass},${aa_nocomma},${mod.fix_or_opt},${mod.position_specificity},${mod.mod_name}' >> Mods.txt &&
         #end for
 
-  msgf_plus
+        msgf_plus
             -s '$input_name'
             -d '$db_name'
             -thread \${GALAXY_SLOTS:-1}
@@ -56,31 +56,31 @@
             -maxCharge $advanced.maxCharge
             -n $advanced.n
             -addFeatures $advanced.addFeatures
-  #if $tsvcheck
-      &&
-      msgf_plus
-          edu.ucsd.msjava.ui.MzIDToTsv
-          -i '$output_name'
-          -o output.tsv
-  #end if
+        #if $tsvcheck
+            &&
+            msgf_plus
+              edu.ucsd.msjava.ui.MzIDToTsv
+              -i '$output_name'
+              -o output.tsv
+        #end if
         &&
         mv '$output_name' output
 ]]>
     </command>
     <inputs>
         <conditional name="msgf_input">
-          <param name="intype_selector" type="select" label="Type of MSGF+ analysis">
-            <option value="single">Single database</option>
-            <option value="fractions">Prefractionated database</option>
-          </param>
-          <when value="single">
-            <param argument="-s" type="data" format="mzml" label="Input Raw MS File(s)"/>
-            <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
-          </when>
-          <when value="fractions">
-      <param name="db_spectra" type="data_collection" collection_type="paired" 
-        label="Collection: Pairs of spectra (forward) and FASTA database (reverse)"/>
-          </when>
+            <param name="intype_selector" type="select" label="Type of MSGF+ analysis">
+                <option value="single">Single database</option>
+                <option value="fractions">Prefractionated database</option>
+            </param>
+            <when value="single">
+                <param argument="-s" type="data" format="mzml" label="Input Raw MS File(s)"/>
+                <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
+              </when>
+              <when value="fractions">
+                  <param name="db_spectra" type="data_collection" collection_type="paired" 
+                      label="Collection: Pairs of spectra (forward) and FASTA database (reverse)"/>
+              </when>
         </conditional>
         <param name="tsvcheck" type="boolean" label="Output TSV as well?" />
         <param argument="-tda" type="boolean" truevalue="1" falsevalue="0" checked="true" label="Search with on-the-fly decoy database?" help="MSGF+ uses XXX_ as an accession prefix to indicate a decoy hit" />

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -33,11 +33,11 @@
         #end for
 
         #for $mod in $custom_mods
-        	#set aa_nocomma = str($mod.aa_specificity).replace(",", "")
+          #set aa_nocomma = str($mod.aa_specificity).replace(",", "")
           echo '${mod.formula_or_mass},${aa_nocomma},${mod.fix_or_opt},${mod.position_specificity},${mod.mod_name}' >> Mods.txt &&
         #end for
 
-	msgf_plus
+  msgf_plus
             -s '$input_name'
             -d '$db_name'
             -thread \${GALAXY_SLOTS:-1}
@@ -56,13 +56,13 @@
             -maxCharge $advanced.maxCharge
             -n $advanced.n
             -addFeatures $advanced.addFeatures
-	#if $tsvcheck
-	    &&
-	    msgf_plus
-	        edu.ucsd.msjava.ui.MzIDToTsv
-	        -i '$output_name'
-	        -o output.tsv
-	#end if
+  #if $tsvcheck
+      &&
+      msgf_plus
+          edu.ucsd.msjava.ui.MzIDToTsv
+          -i '$output_name'
+          -o output.tsv
+  #end if
         &&
         mv '$output_name' output
 ]]>
@@ -78,8 +78,8 @@
             <param argument="-d" type="data" format="fasta" label="Protein Database" help="Select FASTA database from history"/>
           </when>
           <when value="fractions">
-		  <param name="db_spectra" type="data_collection" collection_type="paired" 
-			  label="Collection: Pairs of spectra (forward) and FASTA database (reverse)"/>
+      <param name="db_spectra" type="data_collection" collection_type="paired" 
+        label="Collection: Pairs of spectra (forward) and FASTA database (reverse)"/>
           </when>
         </conditional>
         <param name="tsvcheck" type="boolean" label="Output TSV as well?" />
@@ -308,12 +308,12 @@
             <param name="custom_mods_1|mod_name" value="cGMP" />
             
             <output name="output">
-            		<assert_contents>
-            				<has_text text="iTRAQ4plex">
-            				<has_text text="pyro-Glu">
-            				<has_text text="Gly-loss">
-            				<has_text text="cGMP">
-            		</assert_contents>
+                <assert_contents>
+                    <has_text text="iTRAQ4plex">
+                    <has_text text="pyro-Glu">
+                    <has_text text="Gly-loss">
+                    <has_text text="cGMP">
+                </assert_contents>
             </output>
         </test>
     </tests>

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -309,10 +309,10 @@
             
             <output name="output">
                 <assert_contents>
-                    <has_text text="iTRAQ4plex">
-                    <has_text text="pyro-Glu">
-                    <has_text text="Gly-loss">
-                    <has_text text="cGMP">
+                    <has_text text="iTRAQ4plex" />
+                    <has_text text="pyro-Glu" />
+                    <has_text text="Gly-loss" />
+                    <has_text text="cGMP" />
                 </assert_contents>
             </output>
         </test>

--- a/tools/msgfplus/msgfplus.xml
+++ b/tools/msgfplus/msgfplus.xml
@@ -307,7 +307,14 @@
             <param name="custom_mods_1|position_specificity" value="any" />
             <param name="custom_mods_1|mod_name" value="cGMP" />
             
-            <output name="output" file="201208-378803-msgf_20161026-2mmu-tryptic-many_mods.mzid" lines_diff="6" />
+            <output name="output">
+            		<assert_contents>
+            				<has_text text="iTRAQ4plex">
+            				<has_text text="pyro-Glu">
+            				<has_text text="Gly-loss">
+            				<has_text text="cGMP">
+            		</assert_contents>
+            </output>
         </test>
     </tests>
     <help>


### PR DESCRIPTION
Hi.
Our MSGF+ wrapper had a bug when using custom mods with more than one `aa_specificity`. I fixed this and adapted the last test accordingly. Instead of comparing the diff, the test looks for the identification of the custom mods now.
Cheers, Flo

P.S.: My first steps into Python/Cheetah!