### PR TITLE
Fixed XTandemAdapter: deleted restriction to only one variable mod

### DIFF
--- a/tools/openms/XTandemAdapter.xml
+++ b/tools/openms/XTandemAdapter.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--This is a configuration file for the integration of a tools into Galaxy (https://galaxyproject.org/). This file was automatically generated using CTD2Galaxy.-->
 <!--Proposed Tool Section: [Identification]-->
-<tool id="XTandemAdapter" name="XTandemAdapter" version="2.2.0">
+<tool id="XTandemAdapter" name="XTandemAdapter" version="2.2.0.1">
   <description>Annotates MS/MS spectra using X! Tandem.</description>
   <macros>
     <token name="@EXECUTABLE@">XTandemAdapter</token>
@@ -2665,7 +2665,7 @@
         <option value="trifluoro (L)">trifluoro (L)</option>
       </param>
     </repeat>
-    <repeat name="rep_param_variable_modifications" min="0" max="1" title="param_variable_modifications">
+    <repeat name="rep_param_variable_modifications" min="0" title="param_variable_modifications">
       <param name="param_variable_modifications" type="select" optional="True" label="Variable modifications, specified using Unimod (www.unimod.org) terms," help="(-variable_modifications) e.g. 'Carbamidomethyl (C)' or 'Oxidation (M)'">
         <option value="15N-oxobutanoic (N-term C)">15N-oxobutanoic (N-term C)</option>
         <option value="2-dimethylsuccinyl (C)">2-dimethylsuccinyl (C)</option>


### PR DESCRIPTION
Like in the MSGFPlusAdapter, we had an incorrect restriction that allowed for only one variable modification. Compare https://github.com/galaxyproteomics/tools-galaxyp/pull/210