### PR TITLE
fix column headers in eggnog-mapper

### DIFF
--- a/tools/eggnog_mapper/eggnog_mapper.xml
+++ b/tools/eggnog_mapper/eggnog_mapper.xml
@@ -371,7 +371,7 @@
         <data name="annotations" format="tabular" label="${tool.name} on ${on_string}: ${db.database}.annotations" from_work_dir="results.emapper.annotations">
             <filter>not output_options['no_annot']</filter>
             <actions>
-                <action name="column_names" type="metadata" default="query_name,seed_eggNOG_ortholog,seed_ortholog_evalue,seed_ortholog_score,predicted_gene_name,GO_terms,KEGG_pathways,Annotation_tax_scope,Matching_OGs,best_OG|evalue|score,COG,functional,categories,eggNOG_HMM_model_annotation"/>
+                <action name="column_names" type="metadata" default="query_name,seed_eggNOG_ortholog,seed_ortholog_evalue,seed_ortholog_score,predicted_gene_name,GO_terms,KEGG_KO,BiGG_Reactions,Annotation_tax_scope,Matching_OGs,best_OG|evalue|score,COG_functional_categories,eggNOG_HMM_model_annotation"/>
             </actions>
         </data>
         <data name="hmm_hits" format="tabular" label="${tool.name} on ${on_string}: ${db.database}.hmm_hits"  from_work_dir="results.emapper.hmm_hits">


### PR DESCRIPTION
The column headers in `annotations` changed in 1.0. and I missed it in the original wrapper. 