### PR TITLE
FlashLFQ remove header line from QuantifiedProteins.tsv

### DIFF
--- a/tools/flashlfq/flashlfq.xml
+++ b/tools/flashlfq/flashlfq.xml
@@ -31,6 +31,7 @@
         && cp *_FlashLFQ_QuantifiedBaseSequences.tsv '$quantifiedBaseSequences'
         && cp *_FlashLFQ_QuantifiedModifiedSequences.tsv '$quantifiedModifiedSequences'
         && cp *_FlashLFQ_QuantifiedPeaks.tsv '$quantifiedPeaks'
+        ## create issue for FlashLFQ to name column headers correctly
         && grep -v '^test$' *_FlashLFQ_QuantifiedProteins.tsv > '$quantifiedProteins'
     ]]></command>
     <inputs>

--- a/tools/flashlfq/flashlfq.xml
+++ b/tools/flashlfq/flashlfq.xml
@@ -31,7 +31,7 @@
         && cp *_FlashLFQ_QuantifiedBaseSequences.tsv '$quantifiedBaseSequences'
         && cp *_FlashLFQ_QuantifiedModifiedSequences.tsv '$quantifiedModifiedSequences'
         && cp *_FlashLFQ_QuantifiedPeaks.tsv '$quantifiedPeaks'
-        && cp *_FlashLFQ_QuantifiedProteins.tsv '$quantifiedProteins'
+        && grep -v '^test$' *_FlashLFQ_QuantifiedProteins.tsv > '$quantifiedProteins'
     ]]></command>
     <inputs>
         <param name="idt" type="data" format="tabular" label="identification file" 
@@ -76,7 +76,7 @@
         <data name="quantifiedProteins" format="tabular" label="${tool.name} on ${on_string}: QuantifiedProteins.tsv">
             <actions>
                 <action name="column_names" type="metadata" 
-                 default="Protein"/>
+                 default="Protein,${','.join([i.name for i in $peak_lists])}"/>
             </actions>
         </data>
     </outputs>


### PR DESCRIPTION
The FlashLFQ code only put a single column header “test”  which causes
galaxy to interpret  this as a 1-column tabular file.