### PR TITLE
Updated references SearchGUI from 3.2.13 to 3.2.24, PeptideShaker from 1.16.17 to 1.16.20

### DIFF
--- a/tools/peptideshaker/macros.xml
+++ b/tools/peptideshaker/macros.xml
@@ -49,7 +49,7 @@
 
     </token>
     <token name="@SEARCHGUI_MAJOR_VERSION@">3</token>
-    <token name="@SEARCHGUI_VERSION@">3.2.13</token>
+    <token name="@SEARCHGUI_VERSION@">3.2.24</token>
     <xml name="general_options">
 
         <section name="protein_digest_options" expanded="false" title="Protein Digestion Options">

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -1,4 +1,4 @@
-<tool id="peptide_shaker" name="Peptide Shaker" version="1.16.17">
+<tool id="peptide_shaker" name="Peptide Shaker" version="1.16.20">
     <description>
         Perform protein identification using various search engines based on results from SearchGUI
     </description>
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="1.16.17">peptide-shaker</requirement>
+        <requirement type="package" version="1.16.20">peptide-shaker</requirement>
     </requirements>
     <expand macro="stdio" />
     <command>

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -1,4 +1,4 @@
-<tool id="search_gui" name="Search GUI" version="@SEARCHGUI_VERSION@.4">
+<tool id="search_gui" name="Search GUI" version="@SEARCHGUI_VERSION@.0">
     <description>
         Perform protein identification using various search engines and prepare results for input to Peptide Shaker
     </description>
@@ -158,7 +158,6 @@
                  -ms_amanda_mono ${advanced_options.ms_amanda.ms_amanda_mono}
             #end if
 
-            #* Not working in tests
             #if $advanced_options.myrimatch.myrimatch_advanced == "yes"
                 -myrimatch_min_pep_length ${advanced_options.myrimatch.myrimatch_min_pep_length}
                 -myrimatch_max_pep_length ${advanced_options.myrimatch.myrimatch_max_pep_length}
@@ -176,7 +175,7 @@
                 -myrimatch_num_batches ${advanced_options.myrimatch.myrimatch_num_batches}
                 -myrimatch_max_peak ${advanced_options.myrimatch.myrimatch_max_peak}
             #end if
-            *#
+
 
             #* Not working in tests
             #if $advanced_options.andromeda.andromeda_advanced == "yes"
@@ -456,8 +455,6 @@
                 <option value="OMSSA" selected="True">OMSSA</option>
                 <option value="Comet">Comet</option>
                 <option value="Tide">Tide</option>
-                <!-- Not working in tests
-                -->
                 <option value="MyriMatch">MyriMatch</option>
                 <option value="MS_Amanda">MS_Amanda</option>
                 <!-- Windows only
@@ -846,17 +843,8 @@
                         <option value="tide_export_text" selected="True">Text</option>
                         <option value="tide_export_sqt" >SQT</option>
                         <option value="tide_export_pepxml" >pepxml</option>
-              <!--
-                        MZidentML and Percolator input file options generates files with the format (ie. if we use a spectrum file called ´qExactive01819´):
-                        galaxy/database/jobs_directory/000/88/working/bin/resources/Tide/linux/linux_64bit/crux-output/qExactive01819.tide-search.target.mzid
-                        instead of
-                        galaxy/database/jobs_directory/000/88/working/bin/resources/Tide/linux/linux_64bit/crux-output/qExactive01819.tide-search.mzid
-                        which is the expected one, so current searchgui version gives a "does not exist error".
-              -->
-              <!--
-                        <option value="tide_export_mzid" >MzIdentML</option
+                        <option value="tide_export_mzid" >MzIdentML</option>
                         <option value="tide_export_pin" >Percolator input file</option>
-              -->
                     </param>
 
                     <param name="tide_remove_temp" type="boolean" truevalue="1" falsevalue="0" checked="true"
@@ -866,7 +854,6 @@
 
 
             <!-- MyriMatch ADVANCED PARAMETERS -->
-            <!-- Not working in tests
             <conditional name="myrimatch">
                 <param name="myrimatch_advanced" type="select" label="MyriMatch Options">
                     <option value="yes">Advanced</option>
@@ -874,44 +861,45 @@
                 </param>
                 <when value="no" />
                 <when value="yes">
-                    <param name="myrimatch_min_pep_length"  type="integer" value="6"
+                    <param name="myrimatch_min_pep_length"  type="integer" value="8"
                         label="MyriMatch: Minimum Peptide Length" help="Minimum length for a peptide to be considered" />
                     <param name="myrimatch_max_pep_length"  type="integer" value="30"
                         label="MyriMatch: Maximum Peptide Length" help="Maximum length for a peptide to be considered" />
-                    <param name="myrimatch_min_prec_mass"  type="float" value="0.0"
-                        label="MyriMatch: Minimum Peptide Mass" help="Minimum 1+ mass of parent ion to be considered" />
-                    <param name="myrimatch_max_prec_mass"  type="float" value="10000.0"
-                        label="MyriMatch: Maximum Peptide Mass" help="Maximum 1+ mass of parent ion to be considered" />
+                    <param name="myrimatch_min_prec_mass"  type="float" value="600.0"
+                        label="MyriMatch: Minimum Precursor Mass" help="Minimum precursor mass of parent ion to be considered" />
+                    <param name="myrimatch_max_prec_mass"  type="float" value="5000.0"
+                        label="MyriMatch: Maximum Precursor Mass" help="Maximum precursor mass of parent ion to be considered" />
                     <param name="myrimatch_num_matches"  type="integer" value="10"
                         label="MyriMatch: Maximum Number of Spectrum Matches" help="Set the value for the maximum number of spectrum matches" />
                     <param name="myrimatch_num_ptms"  type="integer" value="2"
-                        label="MyriMatch: Number of PTMs" help="Set the number of PTMS allowed per peptide" />
+                        label="MyriMatch: Max Variable PTMs per Peptide" help="Set the number of PTMS allowed per peptide" />
                     <param name="myrimatch_fragmentation" label="MyriMatch: Fragmentation Method" type="select" help="Choose the fragmentation method used (CID: b,y) or (ETD: c, z*)">
                         <option value="CID" selected="True">CID</option>
+                        <option value="HCD" >HCD</option>
                         <option value="ETD" >ETD</option>
                     </param>
-                    <param name="myrimatch_termini" label="MyriMatch: Number of Enzymatic Termini" type="select" help="Select the number of enzymatic termini">
-                        <option value="0">non-tryptic</option>
-                        <option value="1" >semi-tryptic</option>
-                        <option value="2"  selected="True" >fully-tryptic</option>
+                    <param name="myrimatch_termini" label="MyriMatch: Enzymatic Terminals" type="select" help="Select the number of enzymatic terminals">
+                        <option value="0">None required</option>
+                        <option value="1">At least one</option>
+                        <option value="2" selected="True" >Both</option>
                     </param>
                     <param name="myrimatch_plus_three"  type="boolean" truevalue="1" falsevalue="0" checked="true"
-                        label="MyriMatch: Smart Plus Three Option" help="Defines what algorithms are used to generate a set of theoretical fragment ions" />
+                        label="MyriMatch: Use Smart Plus Three Option" help="Defines what algorithms are used to generate a set of theoretical fragment ions" />
                     <param name="myrimatch_xcorr"  type="boolean" truevalue="1" falsevalue="0" checked="false"
-                        label="MyriMatch: Xcorr Option" help="a Sequest-like cross correlation score can be calculated for the top ranking hits" />
+                        label="MyriMatch: Compute Xcorr" help="a Sequest-like cross correlation score can be calculated for the top ranking hits" />
                     <param name="myrimatch_tic_cutoff"  type="float" value="0.98"
-                        label="MyriMatch: TIC cutoff percentage" help="Cumulative ion current of picked peaks divided by TIC >= this value for peaks to be retained" />
+                        label="MyriMatch: TIC cutoff percentage" help="Cumulative ion current of picked peaks divided by TIC >= this value for peaks to be retained (0.0 - 1.0)" />
                     <param name="myrimatch_intensity_classes"  type="integer" value="3"
                         label="MyriMatch: Number of Intensity Classes" help="Experimental spectra have their peaks stratified into this number of intensity classed" />
                     <param name="myrimatch_class_multiplier"  type="integer" value="2"
-                        label="MyriMatch: Class Multiplier" help="Has to do with previous option, this parameter controls the size of each class relative to the class above" />
+                        label="MyriMatch: Class Size Multiplier" help="Has to do with previous option, this parameter controls the size of each class relative to the class above" />
                     <param name="myrimatch_num_batches"  type="integer" value="50"
                         label="MyriMatch: Number of Batches" help="The number of batches per node to strive for when usinge the MPI-based parallelization features" />
                     <param name="myrimatch_max_peak"  type="integer" value="100"
                         label="MyriMatch: Maximum Peak Count" help="Maximum number of peaks to be used from a spectrum" />
                 </when>
             </conditional>
-            -->
+
 
             <!-- Andromeda ADVANCED PARAMETERS -->
             <!-- Windows only


### PR DESCRIPTION
SearchGUI from 3.2.13 to 3.2.24
PeptideShaker from 1.16.17 to 1.16.20

And:
SearchGUI`s galaxy tool improvements: Myrimatch advanced options following desktop app. model, more Tide exporting options (MzIdentML and Percolator)
