### PR TITLE
fix output path quoting

### DIFF
--- a/tools/openms/MapAlignerPoseClustering.xml
+++ b/tools/openms/MapAlignerPoseClustering.xml
@@ -22,12 +22,12 @@
 
 -out
 #for $counter,$infile in enumerate($param_in):
-    ./results_out/${infile.element_identifier}.${infile.extension}
+    './results_out/${infile.element_identifier}.${infile.extension}'
 #end for
 
 -trafo_out
 #for $counter,$infile in enumerate($param_in):
-    ./results_trafoxml/${infile.element_identifier}.trafoxml
+    './results_trafoxml/${infile.element_identifier}.trafoxml'
 #end for
 
 #if $param_reference_file:


### PR DESCRIPTION
Output paths for `MapAlignerPoseClustering` can contain spaces and must be quoted