### PR TITLE
openms: added out of memory tests

### DIFF
--- a/tools/openms/macros.xml
+++ b/tools/openms/macros.xml
@@ -16,7 +16,7 @@
       <regex match="java.lang.OutOfMemoryError" level="fatal_oom" description="Java memory Exception"/>
       <regex match="Could not allocate metaspace" level="fatal_oom" description="Java memory Exception"/>
       <regex match="Cannot create VM thread" level="fatal_oom" description="Java memory Exception"/>
-      <regex match="Exception:" level="fatal" description="Java Exception"/>
+      <regex match="qUncompress: could not allocate enough memory to uncompress data" level="fatal_oom" description="Java memory Exception"/>
     </stdio>
   </xml>
   <xml name="references">

--- a/tools/openms/macros.xml
+++ b/tools/openms/macros.xml
@@ -13,6 +13,7 @@
     <stdio>
       <exit_code range="1:"/>
       <exit_code range=":-1"/>
+      <regex match="Exception:"/>
       <regex match="java.lang.OutOfMemoryError" level="fatal_oom" description="Java memory Exception"/>
       <regex match="Could not allocate metaspace" level="fatal_oom" description="Java memory Exception"/>
       <regex match="Cannot create VM thread" level="fatal_oom" description="Java memory Exception"/>

--- a/tools/openms/macros.xml
+++ b/tools/openms/macros.xml
@@ -13,7 +13,10 @@
     <stdio>
       <exit_code range="1:"/>
       <exit_code range=":-1"/>
-      <regex match="Exception:"/>
+      <regex match="java.lang.OutOfMemoryError" level="fatal_oom" description="Java memory Exception"/>
+      <regex match="Could not allocate metaspace" level="fatal_oom" description="Java memory Exception"/>
+      <regex match="Cannot create VM thread" level="fatal_oom" description="Java memory Exception"/>
+      <regex match="Exception:" level="fatal" description="Java Exception"/>
     </stdio>
   </xml>
   <xml name="references">


### PR DESCRIPTION
I'm not sure if all tools involve java. Then this should be fine. Alternatively the oom tests could be applied only for java based tools. 

I'm doing this in particular for MSGFPlusAdapter