### PR TITLE
Make moff independent of the display name file-endings

### DIFF
--- a/tools/moFF/moff.xml
+++ b/tools/moFF/moff.xml
@@ -1,4 +1,4 @@
-<tool id="proteomics_moff" name="moFF" version="@VERSION@.1">
+<tool id="proteomics_moff" name="moFF" version="@VERSION@.2">
     <description>extracts MS1 intensities from spectrum files</description>
     <macros>
         <token name="@VERSION@">1.2.1</token>
@@ -63,21 +63,32 @@
             </conditional>
         </xml>
         <!-- tokens (code snippets used in <command>) -->
+        <token name="@FORMAT@"><![CDATA[
+            #if $task.task_selector != 'mbr'
+                #if $task.msms_input.input_type_selector == "raw":
+                    #set $format = '.raw'
+                #else
+                    #set $format = '.mzml'
+                #end if
+            #else:
+                #set $format = '.tabular'
+            #end if
+        ]]></token>
         <token name="@IDENT_INPUT_ARG_MULTIPLE@"><![CDATA[
             ## this is where the ident input gets passed to moff/moff_all/moff_mbr
             --inputtsv
-            #for $key in $task.ident_input.ident_input_file.keys():
-                './ident_inputs/${task.ident_input.ident_input_file[$key].display_name}'
+            #for $value in $task.ident_input.ident_input_file:
+                './ident_inputs/$value.element_identifier$format'
             #end for
         ]]></token>
         <token name="@IDENT_INPUT_ARG_SINGLE@"><![CDATA[
             ## this is where the ident input gets passed to moff/moff_all/moff_mbr
-            --inputtsv './ident_inputs/${task.ident_input.ident_input_file.display_name}'
+            --inputtsv './ident_inputs/${task.ident_input.ident_input_file.element_identifier}$format'
         ]]></token>
         <token name="@WRANGLE_IDENT_INPUT_SINGLE@"><![CDATA[
             mkdir ./ident_inputs &&
             #if $task.ident_input.input_type_selector == "ps":
-                cp '$task.ident_input.ident_input_file' './ident_inputs/$task.ident_input.ident_input_file.display_name' &&
+                cp '$task.ident_input.ident_input_file' './ident_inputs/$task.ident_input.ident_input_file.element_identifier$format' &&
             #else
                 cp '$task.ident_input.ident_input_file' ./tempfile1.tab &&
                 ## optionally remove first line
@@ -87,48 +98,48 @@
                 ## header row with correct names: "peptide", "prot", "mod_peptide", "rt", "mz", "mass", and "charge"
                 echo -e "peptide\tprot\tmod_peptide\trt\tmz\tmass\tcharge" > ./tempfile2.tab &&
                 awk 'BEGIN{OFS="\t"; FS="\t"}{print \$pep,\$prot,\$mod,\$rt,\$mz,\$mass,\$charge}' pep="${task.ident_input.peptide}" prot="$task.ident_input.prot" mod="$task.ident_input.mod_peptide" rt="$task.ident_input.rt" mz="$task.ident_input.mz" mass="$task.ident_input.mass" charge="$task.ident_input.charge" ./tempfile1.tab >> ./tempfile2.tab &&
-                mv ./tempfile2.tab './ident_inputs/$task.ident_input.ident_input_file.display_name' &&
+                mv ./tempfile2.tab './ident_inputs/$task.ident_input.ident_input_file.element_identifier$format' &&
             #end if
         ]]></token>
         <token name="@WRANGLE_IDENT_INPUT_MULTIPLE@"><![CDATA[
             mkdir ./ident_inputs &&
             #if $task.ident_input.input_type_selector == "ps":
-                #for $key in $task.ident_input.ident_input_file.keys():
-                    cp '${task.ident_input.ident_input_file[$key]}' './ident_inputs/${task.ident_input.ident_input_file[$key].display_name}' &&
+                #for $value in $task.ident_input.ident_input_file:
+                    cp '${value}' './ident_inputs/${value.element_identifier}$format' &&
                 #end for
             #else
-                #for $key in $task.ident_input.ident_input_file.keys():
-                    cp '${task.ident_input.ident_input_file[$key]}' './tempfile${key}_1.tab' &&
+                #for $i, $value in enumerate($task.ident_input.ident_input_file):
+                    cp '${value}' './tempfile${i}_1.tab' &&
                     ## optionally remove first line
                     #if $task.ident_input.remove_header:
-                        sed -i '1d' './tempfile${key}_1.tab' &&
+                        sed -i '1d' './tempfile${i}_1.tab' &&
                     #end if
                     ## header row with correct names: "peptide", "prot", "mod_peptide", "rt", "mz", "mass", and "charge"
-                    echo -e "peptide\tprot\tmod_peptide\trt\tmz\tmass\tcharge" > './tempfile${key}_2.tab' &&
-                    awk 'BEGIN{OFS="\t"; FS="\t"}{print \$pep,\$prot,\$mod,\$rt,\$mz,\$mass,\$charge}' pep="${task.ident_input.peptide}" prot="$task.ident_input.prot" mod="$task.ident_input.mod_peptide" rt="$task.ident_input.rt" mz="$task.ident_input.mz" mass="$task.ident_input.mass" charge="$task.ident_input.charge" './tempfile${key}_1.tab' >> './tempfile${key}_2.tab' &&
-                    mv './tempfile${key}_2.tab' './ident_inputs/$task.ident_input.ident_input_file[$key].display_name' &&
+                    echo -e "peptide\tprot\tmod_peptide\trt\tmz\tmass\tcharge" > './tempfile${i}_2.tab' &&
+                    awk 'BEGIN{OFS="\t"; FS="\t"}{print \$pep,\$prot,\$mod,\$rt,\$mz,\$mass,\$charge}' pep="${task.ident_input.peptide}" prot="$task.ident_input.prot" mod="$task.ident_input.mod_peptide" rt="$task.ident_input.rt" mz="$task.ident_input.mz" mass="$task.ident_input.mass" charge="$task.ident_input.charge" './tempfile${i}_1.tab' >> './tempfile${i}_2.tab' &&
+                    mv './tempfile${i}_2.tab' './ident_inputs/${value.element_identifier}$format' &&
                 #end for
             #end if
         ]]></token>
         <token name="@RAW_INPUT_ARG_SINGLE@"><![CDATA[
-            --inputraw './raws/$task.msms_input.inputraw.display_name'
+            --inputraw './raws/$task.msms_input.inputraw.element_identifier$format'
         ]]></token>
         <token name="@RAW_INPUT_ARG_MULTIPLE@"><![CDATA[
             --inputraw
-            #for $key in $task.msms_input.inputraw.keys():
-                './raws/$task.msms_input.inputraw[$key].display_name'
+            #for $value in $task.msms_input.inputraw:
+                './raws/$value.element_identifier$format'
             #end for
         ]]></token>
         <token name="@WRANGLE_RAW_INPUT_SINGLE@"><![CDATA[
             mkdir ./raws &&
-            ## for files, need to softlink the display name to the history item
-            ln -s '$task.msms_input.inputraw' './raws/$task.msms_input.inputraw.display_name' &&
+            ## for files, need to softlink the name to the history item
+            ln -s '$task.msms_input.inputraw' './raws/$task.msms_input.inputraw.element_identifier$format' &&
         ]]></token>
         <token name="@WRANGLE_RAW_INPUT_MULTIPLE@"><![CDATA[
             mkdir ./raws &&
-            ## for files, need to softlink the display name to the history item
-            #for $key in $task.msms_input.inputraw.keys():
-                ln -s '$task.msms_input.inputraw[$key]' './raws/$task.msms_input.inputraw[$key].display_name' &&
+            ## for files, need to softlink the name to the history item
+            #for $value in $task.msms_input.inputraw:
+                ln -s '$value' './raws/$value.element_identifier$format' &&
             #end for
         ]]></token>
     </macros>
@@ -137,6 +148,7 @@
     </requirements>
     <version_command>echo @VERSION@</version_command>
     <command detect_errors="aggressive"><![CDATA[
+        @FORMAT@
         mkdir ./out &&
         #if $task.task_selector == "moff":
             @WRANGLE_IDENT_INPUT_SINGLE@


### PR DESCRIPTION
@caleb-easterly and @jj-umn this PR will make the moff tool independent of the display_name. I got several error reports of people getting errors because the display name had no file ending.