### PR TITLE
PeptideShaker: updated reference to version 1.16.29 + 3 reports

### DIFF
--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -1,4 +1,4 @@
-<tool id="peptide_shaker" name="Peptide Shaker" version="1.16.26">
+<tool id="peptide_shaker" name="Peptide Shaker" version="1.16.29">
     <description>
         Perform protein identification using various search engines based on results from SearchGUI
     </description>
@@ -6,7 +6,7 @@
         <import>macros.xml</import>
     </macros>
     <requirements>
-        <requirement type="package" version="1.16.26">peptide-shaker</requirement>
+        <requirement type="package" version="1.16.29">peptide-shaker</requirement>
     </requirements>
     <expand macro="stdio" />
     <command>
@@ -128,7 +128,7 @@
         ## Generate Reports if the user has selected one of the 8 additional reports
         ## 'cps', 'mzidentML' and 'zip' are not valid options for PeptideShaker
         ## and will not be passed to the command line
-        #if set(["0","1","2","3","4","5","6","7"]).intersection( set( str( $outputs ).split(',') ) ):
+        #if set(["0","1","2","3","4","5","6","7","8","9","10","11"]).intersection( set( str( $outputs ).split(',') ) ):
 
             (peptide-shaker eu.isas.peptideshaker.cmd.ReportCLI
                 --exec_dir="\$cwd/${bin_dir}"
@@ -154,6 +154,10 @@
 
         ## # ls -l \$cwd/output_reports/* ;
 
+        #if '11' in str($outputs).split(','):
+            find \$cwd/output_reports -name '*Extended_PSM_Report*' -exec bash -c 'mv "$0" "psmx.txt"' {} \;
+            ;
+        #end if
         #if '0' in str($outputs).split(','):
             find \$cwd/output_reports -name '*Certificate_of_Analysis*' -exec bash -c 'mv "$0" "certificate.txt"' {} \;
             ;
@@ -166,27 +170,35 @@
             find \$cwd/output_reports -name '*PSM_Phosphorylation_Report*' -exec bash -c 'mv "$0" "psm_phospho.txt"' {} \;
             ;
         #end if
-        #if '8' in str($outputs).split(','):
-            find \$cwd/output_reports -name '*Extended_PSM_Report*' -exec bash -c 'mv "$0" "psmx.txt"' {} \;
+        #if '5' in str($outputs).split(','):
+            find \$cwd/output_reports -name '*Peptide_Phosphorylation_Report*' -exec bash -c 'mv "$0" "peptides_phospho.txt"' {} \;
+            ;
+        #end if
+        #if '4' in str($outputs).split(','):
+            find \$cwd/output_reports -name '*PSM_Report_with_non-validated_matches*' -exec bash -c 'mv "$0" "psm_non_validated.txt"' {} \;
             ;
         #end if
         #if '3' in str($outputs).split(','):
             find \$cwd/output_reports -name '*PSM_Report*' -exec bash -c 'mv "$0" "psm.txt"' {} \;
             ;
         #end if
-        #if '4' in str($outputs).split(','):
-            find \$cwd/output_reports -name '*Peptide_Phosphorylation_Report*' -exec bash -c 'mv "$0" "peptides_phospho.txt"' {} \;
-            ;
-        #end if
-        #if '5' in str($outputs).split(','):
-            find \$cwd/output_reports -name '*Peptide_Report*' -exec bash -c 'mv "$0" "peptides.txt"' {} \;
+        #if '7' in str($outputs).split(','):
+            find \$cwd/output_reports -name '*Peptide_Report_with_non-validated_matches*' -exec bash -c 'mv "$0" "peptides_non_validated.txt"' {} \;
             ;
         #end if
         #if '6' in str($outputs).split(','):
+            find \$cwd/output_reports -name '*Peptide_Report*' -exec bash -c 'mv "$0" "peptides.txt"' {} \;
+            ;
+        #end if
+        #if '8' in str($outputs).split(','):
             find \$cwd/output_reports -name '*Protein_Phosphorylation_Report*' -exec bash -c 'mv "$0" "proteins_phospho.txt"' {} \;
             ;
         #end if
-        #if '7' in str($outputs).split(','):
+        #if '10' in str($outputs).split(','):
+            find \$cwd/output_reports -name '*Protein_Report_with_non-validated_matches*' -exec bash -c 'mv "$0" "proteins_non_validated.txt"' {} \;
+            ;
+        #end if
+        #if '9' in str($outputs).split(','):
             find \$cwd/output_reports -name '*Protein_Report*' -exec bash -c 'mv "$0" "proteins.txt"' {} \;
             ;
         #end if
@@ -302,12 +314,15 @@
             <option value="zip">Zip File for import to Desktop App</option>
             <option value="mzidentML" selected="True">mzidentML File</option>
             <option value="3">PSM Report</option>
-            <option value="8">Extended PSM Report</option>
+            <option value="4">PSM Report with non-validated matches</option>
+            <option value="11">Extended PSM Report</option>
             <option value="2">PSM Phosphorylation Report</option>
-            <option value="5">Peptide Report</option>
-            <option value="4">Peptide Phosphorylation Report</option>
-            <option value="7">Protein Report</option>
-            <option value="6">Protein Phosphorylation Report</option>
+            <option value="6">Peptide Report</option>
+            <option value="7">Peptide Report with non-validated matches</option>
+            <option value="5">Peptide Phosphorylation Report</option>
+            <option value="9">Protein Report</option>
+            <option value="10">Protein Report with non-validated matches</option>
+            <option value="8">Protein Phosphorylation Report</option>
             <option value="0">Certificate of Analysis</option>
             <option value="1">Hierarchical Report</option>
             <option value="cps">CPS file</option>
@@ -337,20 +352,29 @@
         <data format="tabular" name="output_psm" from_work_dir="psm.txt" label="${tool.name} on ${on_string}: PSM Report">
             <filter>'3' in outputs</filter>
         </data>
-        <data format="tabular" name="output_extended_psm" from_work_dir="psmx.txt" label="${tool.name} on ${on_string}: Extended PSM Report">
-            <filter>'8' in outputs</filter>
-        </data>
-        <data format="tabular" name="output_peptides_phosphorylation" from_work_dir="peptides_phospho.txt" label="${tool.name} on ${on_string}: Peptide Phosphorylation Report">
+        <data format="tabular" name="output_psm_non_validated" from_work_dir="psm_non_validated.txt" label="${tool.name} on ${on_string}: PSM Report With Non-Validated Matches ">
             <filter>'4' in outputs</filter>
         </data>
-        <data format="tabular" name="output_peptides" from_work_dir="peptides.txt" label="${tool.name} on ${on_string}: Peptide Report">
+        <data format="tabular" name="output_extended_psm" from_work_dir="psmx.txt" label="${tool.name} on ${on_string}: Extended PSM Report">
+            <filter>'11' in outputs</filter>
+        </data>
+        <data format="tabular" name="output_peptides_phosphorylation" from_work_dir="peptides_phospho.txt" label="${tool.name} on ${on_string}: Peptide Phosphorylation Report">
             <filter>'5' in outputs</filter>
         </data>
-        <data format="tabular" name="output_proteins_phosphorylation" from_work_dir="proteins_phospho.txt" label="${tool.name} on ${on_string}: Protein Phosphorylation Report">
+        <data format="tabular" name="output_peptides" from_work_dir="peptides.txt" label="${tool.name} on ${on_string}: Peptide Report">
             <filter>'6' in outputs</filter>
         </data>
-        <data format="tabular" name="output_proteins" from_work_dir="proteins.txt" label="${tool.name} on ${on_string}: Protein Report">
+        <data format="tabular" name="output_peptides_non_validated" from_work_dir="peptides_non_validated.txt" label="${tool.name} on ${on_string}: Peptide Report With Non-Validated Matches">
             <filter>'7' in outputs</filter>
+        </data>
+        <data format="tabular" name="output_proteins_phosphorylation" from_work_dir="proteins_phospho.txt" label="${tool.name} on ${on_string}: Protein Phosphorylation Report">
+            <filter>'8' in outputs</filter>
+        </data>
+        <data format="tabular" name="output_proteins" from_work_dir="proteins.txt" label="${tool.name} on ${on_string}: Protein Report">
+            <filter>'9' in outputs</filter>
+        </data>
+        <data format="tabular" name="output_proteins_non_validated" from_work_dir="proteins_non_validated.txt" label="${tool.name} on ${on_string}: Protein Report With Non-Validated Matches">
+            <filter>'10' in outputs</filter>
         </data>
     </outputs>
     <tests>
@@ -371,7 +395,7 @@
             <param name="processing_options_selector" value="no"/>
             <param name="filtering_options_selector" value="yes"/>
             <param name="min_peptide_length" value="1"/>
-            <param name="outputs" value="0,1,2,3,4,5,6,7"/>
+            <param name="outputs" value="0,1,2,3,5,6,8,9"/>
             <output name="output_certificate">
                 <assert_contents>
                     <has_text text="Tolerance: 100" />


### PR DESCRIPTION
Added 3 default reports: Default PSM Report with non-validated matches, Default Peptide Report with non-validated matches and Default Protein Report with non-validated matches.

ReportCLI: reports` ids have changed:
0: Certificate of Analysis,
1: Default Hierarchical Report,
2: Default PSM Phosphorylation Report,
3: Default PSM Report,
4: Default PSM Report with non-validated matches,
5: Default Peptide Phosphorylation Report,
6: Default Peptide Report,
7: Default Peptide Report with non-validated matches,
8: Default Protein Phosphorylation Report,
9: Default Protein Report,
10: Default Protein Report with non-validated matches,
11: Extended PSM Report,
12-n: Your own custom reports.