### PR TITLE
added munsell package requirement to QuanTP

### DIFF
--- a/tools/quantp/quantp.xml
+++ b/tools/quantp/quantp.xml
@@ -1,4 +1,4 @@
-<tool id="quantp" name="QuanTP" version="1.1.1">
+<tool id="quantp" name="QuanTP" version="1.1.2">
     <description>Correlation between protein and transcript abundances</description>
     <requirements>
         <requirement type="package" version="1.10.4">r-data.table</requirement>
@@ -8,6 +8,7 @@
         <requirement type="package" version="0.4.5">r-ggfortify</requirement>
         <requirement type="package" version="4.8.0">r-plotly</requirement>
         <requirement type="package" version="0.6.1.1">r-d3heatmap</requirement>
+        <requirement type="package" version="0.5.0">r-munsell</requirement>
     </requirements>
     <command detect_errors="exit_code"><![CDATA[
 Rscript '$__tool_directory__/quantp.r' 


### PR DESCRIPTION
Having some packaging requirements on [z.umn.edu/proteogenomicsgateway](z.umn.edu/proteogenomicsgateway) that need a higher version so I specified it with this update.