### PR TITLE
Fix msconvert where tar filename or dataset name have changed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ jobs:
 
 before_install:
   - export GALAXY_REPO=https://github.com/galaxyproject/galaxy
-  - export GALAXY_RELEASE=release_18.09
+  - export GALAXY_RELEASE=release_19.01
   - export PLANEMO_CONDA_PREFIX="$HOME/conda"
   - unset JAVA_HOME
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,16 +119,16 @@ script:
   - |
     if [ -s changed_tools_chunk.list ]; then
 
-        if grep -Fxq "msconvert" changed_tools_chunk.list
+        if grep -Fq "msconvert" changed_tools_chunk.list
         then
-          planemo test --docker --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
+          planemo test --docker --galaxy_branch "release_19.01" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
         else
           planemo test --conda_dependency_resolution --conda_auto_install --conda_channels iuc,bioconda,conda-forge,defaults --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
         fi
     elif [ -s changed_repositories_chunk.list ]; then
         while read -r DIR; do
             if [[ $DIR == *"msconvert"* ]]; then
-                planemo test --docker --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR"
+                planemo test --docker --galaxy_branch "release_19.01" --galaxy_source "$GALAXY_REPO" "$DIR"
             else
                planemo test --conda_dependency_resolution --conda_auto_install --conda_channels iuc,bioconda,conda-forge,defaults --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR"
             fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -121,14 +121,14 @@ script:
 
         if grep -Fq "msconvert" changed_tools_chunk.list
         then
-          planemo test --docker --galaxy_branch "release_19.01" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
+          planemo test --docker --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
         else
           planemo test --conda_dependency_resolution --conda_auto_install --conda_channels iuc,bioconda,conda-forge,defaults --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" $(cat changed_tools_chunk.list)
         fi
     elif [ -s changed_repositories_chunk.list ]; then
         while read -r DIR; do
             if [[ $DIR == *"msconvert"* ]]; then
-                planemo test --docker --galaxy_branch "release_19.01" --galaxy_source "$GALAXY_REPO" "$DIR"
+                planemo test --docker --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR"
             else
                planemo test --conda_dependency_resolution --conda_auto_install --conda_channels iuc,bioconda,conda-forge,defaults --galaxy_branch "$GALAXY_RELEASE" --galaxy_source "$GALAXY_REPO" "$DIR"
             fi

--- a/tools/msconvert/msconvert_macros.xml
+++ b/tools/msconvert/msconvert_macros.xml
@@ -9,19 +9,30 @@
     #set $ext = $input.ext
 
     ## sanitize display name for use as temp filename
-    #set basename = $re.sub(r'[^\w\.\-\+]','_',$input.element_identifier)
+    #set basename = $re.sub(r'[^\w ,.\-+]','_',$input.element_identifier)
 
     #if $ext == 'wiff':
       ln -s '${input.extra_files_path}/wiff' '${basename}.wiff' &&
       ln -s '${input.extra_files_path}/wiff_scan' '${basename}.wiff.scan' &&
+      #set inputmask = "'"+$basename+"'"
     #elif $ext.endswith('tar'):
       ln -s '$input' '${basename}' &&
       tar xf '${basename}' &&
       #set basename = $os.path.splitext($basename)[0]
+      #if $ext.startswith('waters'):
+        #set inputmask = '*.raw'
+      #elif $ext.startswith('agilent') or $ext.startswith('bruker'):
+        #set inputmask = '*.d'
+      #elif $ext.startswith('wiff'):
+        #set inputmask = '*.wiff *.wiff2'
+      #else
+        #raise RuntimeError("Unrecognized type of tar (${ext})")
+      #end if
     #else
       ln -s '$input' '${basename}' &&
+      #set inputmask = "'"+$basename+"'"
     #end if
-    
+
     #if $data_processing.precursor_refinement.use_mzrefinement
       #set input_ident_name = ".".join((os.path.splitext($basename)[0], $data_processing.precursor_refinement.input_ident.ext))
       #set output_refinement_name = os.path.splitext($basename)[0] + '.mzRefinement.tsv'
@@ -31,7 +42,7 @@
     uid=`id -u` &&
     gid=`id -g` &&
 
-    wine64_anyuser msconvert '${basename}'
+    wine64_anyuser msconvert ${inputmask}
     --outdir outputs
     --${output_type}
 


### PR DESCRIPTION
It's easy to change the tar filename after creating it and the dataset name after uploading it. This would break msconvert which assumed the file/folder inside to be named the same as the tar or data set (minus the tar extension). This patch makes it pass msconvert a pathmask based on the datatype. Technically this shortcut (using wildcards) could produce multiple outputs if someone put multiple raw files in a tar. But a more sophisticated approach - which actually tried to pick the real file/folder in the tar - would only improve matters by virtue of throwing a meaningful error if a tar includes multiple raw files.