### PR TITLE
update metaquantome help documentation

### DIFF
--- a/tools/metaquantome/metaquantome_db.xml
+++ b/tools/metaquantome/metaquantome_db.xml
@@ -39,9 +39,10 @@
     <help>
 <![CDATA[
 metaQuantome database
-===================
+=====================
 
 metaQuantome uses freely available bioinformatic databases to expand your set of direct annotations.
+For most cases, all 3 databases can be downloaded (the default).
 
 The databases are:
 
@@ -57,11 +58,12 @@ http://geneontology.org/docs/download-ontology/
 relationships between them.
 
 This module downloads the most recent releases of the specified databases and stores them in a single file, which can then
-be accessed by the rest of the metaQuantome modules. For most cases, all 3 databases can be downloaded (the default). For reference,
+be accessed by the rest of the metaQuantome modules.  For reference,
 the taxonomy database is the largest (~500 Mb), while the GO and EC databases are smaller: ~34 Mb and ~10Mb, respectively.
 
-Also, note that the databases will be stored and not modified, so the date of download can be referenced later. The important exception
-to this is the NCBI database, which is updated every time it is loaded by the ete3 package, used within metaQuantome.
+Also, note that the databases will be stored in the history so that the date of download can be referenced later.
+Thus, the databases will not be modified, except for the NCBI database, which is updated every time ``metaQuantome: expand`` is run (this
+is a limitation of the Python package ete3, used within metaQuantome).
 
 Questions, Comments, Problems, Kudos
 ------------------------------------

--- a/tools/metaquantome/metaquantome_db.xml
+++ b/tools/metaquantome/metaquantome_db.xml
@@ -38,7 +38,7 @@
     </tests>
     <help>
 <![CDATA[
-metaQuantome db
+metaQuantome database
 ===================
 
 metaQuantome uses freely available bioinformatic databases to expand your set of direct annotations.
@@ -53,7 +53,7 @@ files are used: the go-basic.obo file, which is a simplified version of the GO d
 and the metagenomics slim GO, which is a subset of the full GO that is useful for microbiome research. More details are available at
 http://geneontology.org/docs/download-ontology/
 
-3. ENZYME database, with Enzyme Classification (EC) numbers. This database classifies enzymes and organizes the
+3. ENZYME database with Enzyme Classification (EC) numbers. This database classifies enzymes and organizes the
 relationships between them.
 
 This module downloads the most recent releases of the specified databases and stores them in a single file, which can then
@@ -66,7 +66,7 @@ to this is the NCBI database, which is updated every time it is loaded by the et
 Questions, Comments, Problems, Kudos
 ------------------------------------
 
-Please file any issues at https://github.com/galaxyproteomics/tools-galaxyp/issues.`
+Please file any issues at https://github.com/galaxyproteomics/tools-galaxyp/issues.
 ]]></help>
     <expand macro="citations" />
 </tool>

--- a/tools/metaquantome/metaquantome_expand.xml
+++ b/tools/metaquantome/metaquantome_expand.xml
@@ -163,7 +163,7 @@ and can be run to analyze function, taxonomy, or function and taxonomy together.
 
 To prepare to run this module, you must create your samples file with
 "metaQuantome: create samples file" and download the necessary databases with
-"metaQuantome: download".
+"metaQuantome: database".
 
 Some example analysis workflows are:
 
@@ -175,19 +175,19 @@ Some example analysis workflows are:
 The following information is required for all 3 analysis modes
 (function, taxonomy, and function-taxonomy).
 
-- experimental design information
-- a tab-separated peptide intensity file
-- the name of the peptide column in the intensity file
+- experimental design information.
+- a tab-separated peptide intensity file.
+- the name of the peptide column in the intensity file.
 
 Function mode
 -------------
 
 In function mode, the following information is required:
 
-- the ontology being used: Gene Ontology (go), Clusters of Orthologous Groups (COG), or Enzyme Commission (EC) numbers.
-- a tab-separated functional annotation file, with a peptide column and a functional annotation column. An entry in the functional annotation column may contain multiple functional annotations separated by a comma.
-- the name of the peptide column in the functional annotation file
-- the name of the functional annotation column in the functional annotation file
+- the ontology being used: Gene Ontology (GO), Clusters of Orthologous Groups (COG), or Enzyme Commission (EC) numbers.
+- a tab-separated functional annotation file, with a peptide column and a functional annotation column. An entry in the functional annotation column may contain multiple functional annotations separated by commas.
+- the name of the peptide column in the functional annotation file.
+- the name of the functional annotation column in the functional annotation file.
 
 Taxonomy mode
 -------------
@@ -195,8 +195,8 @@ Taxonomy mode
 In taxonomy mode, the following information is required:
 
 - a tab-separated taxonomy annotation file, with a peptide column and a taxonomy annotation column. The taxonomic annotations should be the lowest common ancestor (LCA) for each peptide, preferably given as NCBI taxonomy IDs.
-- the name of the peptide column in the taxonomic annotation file
-- the name of the taxonomy annotation column in the taxonomy annotation file
+- the name of the peptide column in the taxonomic annotation file.
+- the name of the taxonomy annotation column in the taxonomy annotation file.
 
 Function-Taxonomy mode
 ----------------------
@@ -216,7 +216,7 @@ term id  info about term.         mean term intensity      term intensity       
 term1    name, rank, etc.         note that this           this is the log2        integer. 0 is coded as NA  integer. 0 is coded as NA
                                   is the log2 of the mean  of term intensity
                                   intensity                in each sample.
-                                                           missing data is coded
+                                                           Missing data is coded
                                                            as NA.
 =======  =======================  =======================  ======================  =========================  ==========================
 
@@ -228,7 +228,7 @@ number of sample children.
 Questions, Comments, Problems, Kudos
 ------------------------------------
 
-Please file any issues at https://github.com/galaxyproteomics/tools-galaxyp/issues.`
+Please file any issues at https://github.com/galaxyproteomics/tools-galaxyp/issues.
 ]]></help>
   <expand macro="citations" />
 </tool>


### PR DESCRIPTION
Just some minor fix suggestions in the help documentation for the expand and database modules.

For the database module, I wasn't entirely sure what this describes:

> Also, note that the databases will be stored and not modified, so the date of download can be referenced later. The important exception to this is the NCBI database, which is updated every time it is loaded by the ete3 package, used within metaQuantome.

Does this mean that the NCBI database is built in to metaQuantome? In other words, it is not downloaded into the output Galaxy dataset?

Also, I saw that the visualize module does not get the correct column for the **Taxonomic rank to restrict to in the plot** in the **Taxonomic analysis** mode. As it is on MPG, I see that it gets the namespace column (index 3 I believe). Seems like you fixed this to be the 5th index, which looks correct.