### PR TITLE
Remove list-style terminating ,s from format attributes

### DIFF
--- a/tools/cardinal/preprocessing.xml
+++ b/tools/cardinal/preprocessing.xml
@@ -494,7 +494,7 @@ if (ncol(msidata)>0 & nrow(msidata) >0){
                             <expand macro="reading_1_column_mz_tabular" label="Tabular file with m/z features to use for alignment. Only the m/z values from the tabular file will be kept."/>
                         </when>
                         <when value="align_msidata_ref">
-                            <param name="align_peaks_msidata" type="data" format="rdata," label="Picked and aligned Cardinal MSImageSet saved as RData"/>
+                            <param name="align_peaks_msidata" type="data" format="rdata" label="Picked and aligned Cardinal MSImageSet saved as RData"/>
                         </when>
                     </conditional>
                 </when>
@@ -543,7 +543,7 @@ if (ncol(msidata)>0 & nrow(msidata) >0){
                                     <expand macro="reading_1_column_mz_tabular" label="Tabular file with m/z features to extract from input file"/>
                                 </when>
                                 <when value="msidata_ref">
-                                    <param name="peaks_msidata" type="data" format="rdata," label="Picked and aligned Cardinal MSImageSet saved as RData"/>
+                                    <param name="peaks_msidata" type="data" format="rdata" label="Picked and aligned Cardinal MSImageSet saved as RData"/>
                                 </when>
                             </conditional>
                         </when>

--- a/tools/openms/LowMemPeakPickerHiResRandomAccess.xml
+++ b/tools/openms/LowMemPeakPickerHiResRandomAccess.xml
@@ -104,7 +104,7 @@
       </param>
     </repeat>
     <param name="param_algorithm_report_FWHM" display="radio" type="boolean" truevalue="-algorithm:report_FWHM" falsevalue="" checked="false" optional="True" label="Add metadata for FWHM (as floatDataArray named 'FWHM' or 'FWHM_ppm', depending on param 'report_FWHM_unit') for each picked peak" help="(-report_FWHM) "/>
-    <param name="param_algorithm_report_FWHM_unit" display="radio" type="select" optional="False" value="relative" label="Unit of FWHM. Either absolute in the unit of input," help="(-report_FWHM_unit) e.g. 'm/z' for spectra, or relative as ppm (only sensible for spectra, not chromatograms)">
+    <param name="param_algorithm_report_FWHM_unit" display="radio" type="select" optional="False" value="relative" label="Unit of FWHM. Either absolute in the unit of input" help="(-report_FWHM_unit) e.g. 'm/z' for spectra, or relative as ppm (only sensible for spectra, not chromatograms)">
       <option value="relative" selected="true">relative</option>
       <option value="absolute">absolute</option>
     </param>


### PR DESCRIPTION
While this style is currently tolerated by Galaxy, it prevents correct param format detection in the API and, thus, interferes with scripts trying to extract meaningful info from your tool wrappers.

Autodetection of the pattern also fixed a param label :-)