### PR TITLE
Fix typo in peptideshaker

### DIFF
--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -30,7 +30,7 @@
 
 
         peptide-shaker eu.isas.peptideshaker.cmd.PathSettingsCLI
-	         --exec_dir="\$cwd/${bin_dir}"
+            --exec_dir="\$cwd/${bin_dir}"
             -temp_folder \$cwd/PathSettingsCLI
             -log \$cwd/peptideshaker.log &&
 
@@ -38,7 +38,7 @@
             #set $output_reports_list = set(str($exporting_options.output_reports).split(','))
         #else
             #set $output_reports_list = set()
-	      #end if
+        #end if
 
         ######################
         ## PeptideShakerCLI ##
@@ -53,9 +53,9 @@
             -identification_files \$cwd/searchgui_input.zip
             -id_params \$cwd/SEARCHGUI_IdentificationParameters.par
             -out \$cwd/peptideshaker_output.cpsx
-	      #if $exporting_options.zip_conditional.zip_output_boolean == 'zip':
-            -zip \$cwd/peptideshaker_output.zip
-	      #end if
+            #if $exporting_options.zip_conditional.zip_output_boolean == 'zip':
+                -zip \$cwd/peptideshaker_output.zip
+            #end if
             -threads "\${GALAXY_SLOTS:-12}"
 
         ##Optional processing parameters:
@@ -135,7 +135,7 @@
             && unzip \$cwd/peptideshaker_output.zip 'reports/*' -d \$cwd/output_reports
         #end if
 
-        #if len(output_reports_list)>0:
+        #if len($output_reports_list)>0:
             #if '0' in $output_reports_list:
                 && find \$cwd/output_reports -name '*Certificate_of_Analysis.txt' -exec bash -c 'mv "$0" "certificate.txt"' {} \;
             #end if

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -135,7 +135,7 @@
             && unzip \$cwd/peptideshaker_output.zip 'reports/*' -d \$cwd/output_reports
         #end if
 
-	      #if len(output_reports_list)>0:
+        #if len(output_reports_list)>0:
             #if '0' in $output_reports_list:
                 && find \$cwd/output_reports -name '*Certificate_of_Analysis.txt' -exec bash -c 'mv "$0" "certificate.txt"' {} \;
             #end if
@@ -144,7 +144,7 @@
             #end if
             #if '2' in $output_reports_list:
                 && find \$cwd/output_reports -name '*Default_PSM_Phosphorylation_Report.txt' -exec bash -c 'mv "$0" "psm_phospho.txt"' {} \;
-            #end if`
+            #end if
             #if '3' in $output_reports_list:
                 && find \$cwd/output_reports -name '*Default_PSM_Report.txt' -exec bash -c 'mv "$0" "psm.txt"' {} \;
             #end if


### PR DESCRIPTION
Leads to the following otherwise

```
Invalid Syntax
Line 129, column 20

Line|Cheetah Code
----|-------------------------------------------------------------
126 |            #end if
127 |            #if '2' in $output_reports_list:
128 |                && find \$cwd/output_reports -name '*Default_PSM_Phosphorylation_Report.txt' -exec bash -c 'mv "$0" "psm_phospho.txt"' {} \;
129 |            #end if`
                        ^
130 |            #if '3' in $output_reports_list:
131 |                && find \$cwd/output_reports -name '*Default_PSM_Report.txt' -exec bash -c 'mv "$0" "psm.txt"' {} \;
132 |            #end if
```