### PR TITLE
flashlfq: detect mzML reading error

### DIFF
--- a/tools/flashlfq/flashlfq.xml
+++ b/tools/flashlfq/flashlfq.xml
@@ -3,7 +3,10 @@
     <requirements>
         <requirement type="package" version="1.0.3">flashlfq</requirement>
     </requirements>
-    <command><![CDATA[
+    <stdio>
+        <regex match="Problem opening .mzML file" level="fatal" source="stdout" description="Proplem opening mzML file." />
+    </stdio>
+    <command detect_errors="exit_code"><![CDATA[
         #import re
         #set $idt_path = $re.sub('\s','_',$re.sub('[.][^.]*$','',$idt.display_name.split('/')[-1])) + ".psmtsv"
         ln -s '${idt}' '${idt_path}' &&
@@ -45,7 +48,7 @@
                 #end if
             #end if
         #end if
-        --out out > logfile.txt
+        --out out | tee logfile.txt
     ]]></command>
     <inputs>
         <param argument="--idt" type="data" format="tabular" label="identification file"

--- a/tools/flashlfq/flashlfq.xml
+++ b/tools/flashlfq/flashlfq.xml
@@ -1,4 +1,4 @@
-<tool id="flashlfq" name="FlashLFQ" version="1.0.3.0">
+<tool id="flashlfq" name="FlashLFQ" version="1.0.3.1">
     <description>ultrafast label-free quantification for mass-spectrometry proteomics</description>
     <requirements>
         <requirement type="package" version="1.0.3">flashlfq</requirement>


### PR DESCRIPTION
In the containerized test the logfile contains

```
Problem opening .mzML file ./spectrum_dir/sliced-mzml.mzML; One or more errors occurred.
```

which is now at least detected. Problem still persists. Odd thing is that some output files are still produced... maybe non-fatal error?