### PR TITLE
thermorawfileparser: fix capitalization of requirement

### DIFF
--- a/tools/ThermoRawFileParser/thermo_converter.xml
+++ b/tools/ThermoRawFileParser/thermo_converter.xml
@@ -1,15 +1,11 @@
 <tool id="thermo_raw_file_converter" name="Thermo" version="1.1.10">
     <description>RAW file converter</description>
     <requirements>
-        <requirement type="package" version="1.1.10">ThermoRawFileParser</requirement>
+        <requirement type="package" version="1.1.10">thermorawfileparser</requirement>
     </requirements>
     <command>
 <![CDATA[
 #import re
-
-#set $temp_stderr = "thermo_converter_stderr"
-
-echo "" > $temp_stderr &&
 
 mkdir ./raws_folder &&
 mkdir ./output_folder &&
@@ -22,7 +18,7 @@ mkdir ./output_folder &&
     #end if
 #end for
 
-(ThermoRawFileParser.sh
+ThermoRawFileParser.sh
     -d=./raws_folder
     -o=./output_folder
     -f=$output_format
@@ -33,29 +29,23 @@ mkdir ./output_folder &&
     $peakpicking_boolean
     $ignore_instrument_errors_boolean
 
-    2>> $temp_stderr)
-
-    &&
-
     #if len($input) == 1:
         #if $output_format == "0":
-            mv ./output_folder/input.mgf ./output_file.out &&
+           && mv ./output_folder/input.mgf ./output_file.out
         #else if $output_format == "1":
-            mv ./output_folder/input.mzML ./output_file.out &&
+           && mv ./output_folder/input.mzML ./output_file.out
         #else if $output_format == "2":
-            mv ./output_folder/input.mzML ./output_file.out &&
+           && mv ./output_folder/input.mzML ./output_file.out
         #end if
 
         #if $output_metadata_selector != "off":
             #if $output_metadata_selector == "0":
-                mv ./output_folder/input-metadata.json ./input-metadata.txt &&
+               && mv ./output_folder/input-metadata.json ./input-metadata.txt
             #else if $output_metadata_selector == "1":
-                mv ./output_folder/input-metadata.txt ./input-metadata.txt &&
+               && mv ./output_folder/input-metadata.txt ./input-metadata.txt
             #end if
         #end if
     #end if
-
-    cat $temp_stderr 2>&1;
 ]]>
     </command>
     <inputs>
@@ -136,17 +126,17 @@ mkdir ./output_folder &&
     <tests>
         <!-- Basic test -->
         <test expect_num_outputs="1">
-            <param name="input" value="really_small.raw"/>
+            <param name="input" value="really_small.raw" ftype="thermo.raw"/>
             <param name="output_format" value="1"/>
             <output name="output" file="really_small.mzml" ftype="mzml" compare="sim_size" delta="3000" />
         </test>
 
         <!-- Testing contents of converted mgf file with txt metadata -->
         <test expect_num_outputs="2">
-            <param name="input" value="really_small.raw"/>
+            <param name="input" value="really_small.raw" ftype="thermo.raw"/>
             <param name="output_format" value="0"/>
             <param name="output_metadata_selector" value="1"/>
-            <output name="output">
+            <output name="output" ftype="mgf">
                 <assert_contents>
                     <has_text text="SCANS=36"/>
                     <has_text text="RTINSECONDS=73.863181104"/>
@@ -176,7 +166,7 @@ mkdir ./output_folder &&
 
         <!-- Basic mzml collection test -->
         <test expect_num_outputs="1">
-            <param name="input" value="really_small.raw,really_small_2.raw"/>
+            <param name="input" value="really_small.raw,really_small_2.raw" ftype="thermo.raw"/>
             <param name="output_format" value="1"/>
             <output_collection name="output_mzml_collection" type="list" count="2"/>
         </test>


### PR DESCRIPTION
- also remove superficial redirections
- by setting the ftype in the tests the warnings
  `Datatype class not found for extension 'raw'`
  disappear