### PR TITLE
Using full file locations as arguments to avoid relative-paths ...

### DIFF
--- a/tools/ThermoRawFileParser/thermo_converter.xml
+++ b/tools/ThermoRawFileParser/thermo_converter.xml
@@ -7,6 +7,7 @@
 <![CDATA[
 #import re
 
+cwd=`pwd` &&
 mkdir ./raws_folder &&
 mkdir ./output_folder &&
 #for $input_raw in $input:
@@ -19,8 +20,8 @@ mkdir ./output_folder &&
 #end for
 
 ThermoRawFileParser.sh
-    -d=./raws_folder
-    -o=./output_folder
+    -d="\$cwd/raws_folder"
+    -o="\$cwd/output_folder"
     -f=$output_format
     #if $output_metadata_selector != "off":
         --metadata="${output_metadata_selector}"


### PR DESCRIPTION
problems with some search engines using mzml files.

We have experienced with MetaMorpheus search engine (and it may happen with other search engines) that, when loading mzml files created with ThermoRawFileParser galaxy tool, the search engine crashes trying to load from the .mzml this part:

`

      ...
      <sourceFile id="RAW1" name="input" location="./raws_folder/input.raw">
        ...
      </sourceFile>
      ...
`

as it expects in "location" attribute an absolute path; instead, we were writing there a relative path and, even when "./raws_folder/input.raw" is not used at all out of galaxy, just processing the sourceFile element causes this problem.

This modification writes the absolute path of the source raw file to the .mzl, avoiding this problem. 
By the way, I think this is not as misleading as the relative-path method, as it will be obvius when checking the .mzml that the file location attribute will make reference to a galaxy internal folder, whilst having a relative path there may suggest we should have in our computer some "raws_folder/input.raw" file.

Greetings,
Carlos