### PR TITLE
Fix typo in regex_tabular.xml command

### DIFF
--- a/tools/regex_find_replace/regex_tabular.xml
+++ b/tools/regex_find_replace/regex_tabular.xml
@@ -4,7 +4,7 @@
     <requirement type="package" version="3.7">python</requirement>
   </requirements>
   <command>
-    python '$__tool_requirements__/regex.py'
+    python '$__tool_directory__/regex.py'
       --input '$input'
       --output '$out_file1'
       --column $field


### PR DESCRIPTION
Hi galaxyp, regexColumn was failing tests when we upgraded regex_find_replace.  The tests pass with this fix.  Regards, Catherine (Galaxy Australia)
