### PR TITLE
Allow only mgf scans, update latest version of jar

### DIFF
--- a/tools/mz_to_sqlite/mz_to_sqlite.xml
+++ b/tools/mz_to_sqlite/mz_to_sqlite.xml
@@ -1,13 +1,13 @@
-<tool id="mz_to_sqlite" name="mz to sqlite" version="2.0.2">
+<tool id="mz_to_sqlite" name="mz to sqlite" version="2.0.4">
     <description>Extract mzIdentML and associated proteomics datasets into a SQLite DB</description>
     <requirements>
-      <requirement type="package" version="2.0.2">mztosqlite</requirement>
+        <requirement type="package" version="2.0.4">mztosqlite</requirement>
     </requirements>
-   <stdio>
-       <exit_code range="1:"  level="fatal" description="Error Running mz_to_sqlite" />
-   </stdio>
+    <stdio>
+        <exit_code range="1:" level="fatal" description="Error Running mz_to_sqlite" />
+    </stdio>
     <command>
-<![CDATA[
+        <![CDATA[
 mz_to_sqlite -Xms1g -Xmx6g 
      -numthreads "\${GALAXY_SLOTS:-4}"
      -dbname 'sqlite.db'
@@ -28,13 +28,12 @@ mz_to_sqlite -Xms1g -Xmx6g
 ]]>
     </command>
     <inputs>
-        <param name="mzinput" type="data" format="mzid" label="Proteomics Identification files"/>
-        <param name="scanfiles" type="data" format="mzml,mgf" multiple="true" optional="true" label="Proteomics Spectrum files"/>
-        <param name="searchdbs" type="data" format="fasta,uniprotxml" multiple="true" optional="true" label="Proteomics Search Database Fasta"
-               help="These can provide sequences and length for proteins if not already present in the mzIdentML input"/>
+        <param name="mzinput" type="data" format="mzid" label="Proteomics Identification files" />
+        <param name="scanfiles" type="data" format="mgf" multiple="true" optional="true" label="Proteomics Spectrum files" />
+        <param name="searchdbs" type="data" format="fasta,uniprotxml" multiple="true" optional="true" label="Proteomics Search Database Fasta" help="These can provide sequences and length for proteins if not already present in the mzIdentML input" />
     </inputs>
     <outputs>
-        <data format="mz.sqlite" name="sqlite_db" label="${tool.name} on ${on_string}" from_work_dir="sqlite.db"/>
+        <data format="mz.sqlite" name="sqlite_db" label="${tool.name} on ${on_string}" from_work_dir="sqlite.db" />
     </outputs>
     <tests>
         <test>
@@ -45,7 +44,7 @@ mz_to_sqlite -Xms1g -Xmx6g
         </test>
     </tests>
     <help>
-<![CDATA[
+        <![CDATA[
 ** mz_to_sqlite  converts proteomics file formats to a SQLite database**
 
 ]]>


### PR DESCRIPTION
Update: mztosqlite executor.awaitTermination flow modified to better handle large data sets processed in low resource environments. Especially when run with only 1 thread. This updates to revised recipe version