### PR TITLE
Remove coded JVM heap options, rely on _JAVA_OPTIONS

### DIFF
--- a/tools/mz_to_sqlite/README.md
+++ b/tools/mz_to_sqlite/README.md
@@ -1,0 +1,19 @@
+# MzToSQLite
+
+## Description
+
+Parses MzIdentML, FASTA and MGF scan files into a SQLite3 database. The schema is used by MVPApplication in visualizing the parsed data.
+
+## General Requirements
+
+MzToSQLite is threaded during the read stages of processing. It is single threaded during SQL writes. It will perform best when given one core per MGF file. But it runs well with between two and four cores.
+
+Reading the MGF files is memory intensive, set the _JAVA_OPTIONS to the minimum recommended below.
+
+**Example Recommended Settings**
+
+    One core, minimum memory:
+        _JAVA_OPTIONS: -Xms20G -Xmx20G
+
+    Four core, slightly faster performance (performance determined by size of each MGF file):
+        _JAVA_OPTIONS: -Xms40G -Xmx40G

--- a/tools/mz_to_sqlite/mz_to_sqlite.xml
+++ b/tools/mz_to_sqlite/mz_to_sqlite.xml
@@ -1,4 +1,4 @@
-<tool id="mz_to_sqlite" name="mz to sqlite" version="2.1.0">
+<tool id="mz_to_sqlite" name="mz to sqlite" version="2.0.4+galaxy1">
     <description>Extract mzIdentML and associated proteomics datasets into a SQLite DB</description>
     <requirements>
         <requirement type="package" version="2.0.4">mztosqlite</requirement>

--- a/tools/mz_to_sqlite/mz_to_sqlite.xml
+++ b/tools/mz_to_sqlite/mz_to_sqlite.xml
@@ -1,4 +1,4 @@
-<tool id="mz_to_sqlite" name="mz to sqlite" version="2.0.4">
+<tool id="mz_to_sqlite" name="mz to sqlite" version="2.1.0">
     <description>Extract mzIdentML and associated proteomics datasets into a SQLite DB</description>
     <requirements>
         <requirement type="package" version="2.0.4">mztosqlite</requirement>
@@ -8,7 +8,7 @@
     </stdio>
     <command>
         <![CDATA[
-mz_to_sqlite -Xms1g -Xmx6g 
+mz_to_sqlite
      -numthreads "\${GALAXY_SLOTS:-4}"
      -dbname 'sqlite.db'
      -mzid '$mzinput'


### PR DESCRIPTION
Modified xml from using coded -Xms<n> -Xmx<n> values to relying on _JAVA_OPTIONS environment variable.
Increased version number.