### PR TITLE
ThermoRawFileConverter: Fixed filters for working with workflows.

### DIFF
--- a/tools/ThermoRawFileParser/thermo_converter.xml
+++ b/tools/ThermoRawFileParser/thermo_converter.xml
@@ -1,4 +1,4 @@
-<tool id="thermo_raw_file_converter" name="Thermo" version="1.2.3">
+<tool id="thermo_raw_file_converter" name="Thermo" version="1.2.3.1">
     <description>RAW file converter</description>
     <requirements>
         <requirement type="package" version="1.2.3">thermorawfileparser</requirement>
@@ -79,7 +79,7 @@ ThermoRawFileParser.sh
         <!-- We use simple data outputs if we just have one file, for backwards compatibility -->
 
         <data name="output" format="mzml" from_work_dir="output_file.out" label="${tool.name} on ${on_string}">
-            <filter>(str(input)).count(',') == 0</filter> <!-- funny way of counting the number of input files! -->
+            <filter>len(input) == 1</filter>
             <change_format>
                 <when input="output_format" value="0" format="mgf" />
                 <when input="output_format" value="2" format="txt" />
@@ -88,7 +88,7 @@ ThermoRawFileParser.sh
 
         <data name="output_metadata" format="txt" label="${tool.name} on ${on_string}: Metadata" from_work_dir="input-metadata.txt">
             <filter>str(output_metadata_selector) != "off"</filter>
-            <filter>(str(input)).count(',') == 0</filter>
+            <filter>len(input) == 1</filter>
             <change_format>
                 <when input="output_metadata_selector" value="0" format="json" />
             </change_format>
@@ -98,25 +98,25 @@ ThermoRawFileParser.sh
 
         <collection name="output_mgf_collection" type="list" label="${tool.name} on ${on_string}: MGF">
             <filter>output_format == "0"</filter>
-            <filter>(str(input)).count(',') > 0</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.mgf" directory="output_folder" ext="mgf"/>
+            <filter>len(input) > 1</filter>
+            <discover_datasets pattern="__name_and_ext__" directory="output_folder" ext="mgf"/>
         </collection>
 
         <collection name="output_mzml_collection" type="list" label="${tool.name} on ${on_string}: mzML">
             <filter>output_format == "1"</filter>
-            <filter>(str(input)).count(',') > 0</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.mzML" ext="mzml" directory="output_folder"/>
+            <filter>len(input) > 1</filter>
+            <discover_datasets pattern="__name_and_ext__" ext="mzml" directory="output_folder"/>
         </collection>
 
         <collection name="output_indexedmzml_collection" type="list" label="${tool.name} on ${on_string}: Indexed mzML">
             <filter>output_format == "2"</filter>
-            <filter>(str(input)).count(',') > 0</filter>
-            <discover_datasets pattern="(?P&lt;designation&gt;.+)\.mzML" ext="mzml" directory="output_folder"/>
+            <filter>len(input) > 1</filter>
+            <discover_datasets pattern="__name_and_ext__" ext="mzml" directory="output_folder"/>
         </collection>
 
         <collection name="output_metadata_collection" type="list" label="${tool.name} on ${on_string}: metadata">
             <filter>output_metadata_selector != "off"</filter>
-            <filter>(str(input)).count(',') > 0</filter>
+            <filter>len(input) > 1</filter>
             <discover_datasets pattern="(?P&lt;designation&gt;.+)-metadata.txt" ext="txt" directory="output_folder"/>
             <discover_datasets pattern="(?P&lt;designation&gt;.+)-metadata.json" ext="json" directory="output_folder"/>
         </collection>


### PR DESCRIPTION
Testing a workflow with ThermoRawFileConverter and SearchGUI we have detected that the counting filters applied to the collection outputs were not working properly as the output was never generated (they seemed to work using the graphical interface). 
As the syntax was quite rudimentary I've improved them in all outputs and they seem to work both in the GUI and in the workflow.