### PR TITLE
Update PepQuery to version 1.6

### DIFF
--- a/tools/pepquery/macros.xml
+++ b/tools/pepquery/macros.xml
@@ -1,5 +1,5 @@
  <macros>
-    <token name="@VERSION@">1.3.0</token>
+    <token name="@VERSION@">1.6.0</token>
     <xml name="modifications">
         <option value="1">HexNAc of T (203.07937251951) modaa</option>
         <option value="2">HexNAc of S (203.07937251951) modaa</option>

--- a/tools/pepquery/pepquery.xml
+++ b/tools/pepquery/pepquery.xml
@@ -41,6 +41,7 @@
                         #end if
                     #end if
                 #end if
+                -indexType $req_inputs.indexType
                 #if $modifications.fixed_mod
                 -fixMod '$modifications.fixed_mod'
                 #end if
@@ -144,6 +145,10 @@
             </conditional>
             <param name="db_file" type="data" format="fasta" label="Protein Reference Database File" argument="-db" help="an input sequence that matches a reference will be ignored." />
             <param name="spectrum_file" type="data" format="mgf" label="Spectrum File" argument="-ms" help="Spectrum file used for identification, mgf format" />
+            <param name="indexType" type="select" label="Report Spectrum Scan as" argument="-indexType" help="" >
+                <option value="1" selected="true">index (1-based) in MGF</option>
+                <option value="2">spectrum title in MGF</option>
+            </param>
         </section>
         <section name="modifications" title="Modifications" expanded="false">
              <param name="fixed_mod" type="select" label="Fixed modification(s)" multiple="true" argument="-fixMod" help="Fixed modification">


### PR DESCRIPTION
Add capability to report Spectrum Scan Title instead of scan index.