### PR TITLE
Update cardinal tests so that they can pass in parallel with ephemeris

### DIFF
--- a/tools/cardinal/macros.xml
+++ b/tools/cardinal/macros.xml
@@ -302,20 +302,20 @@ echo $(R --version | grep version | grep -v GNU)", Cardinal version" $(R --vanil
         </citations>
     </xml>
     <xml name="infile_analyze75">
-        <param name="infile" value="" ftype="analyze75">
+        <param name="infile" value="infile_analyze75" ftype="analyze75">
             <composite_data value="Analyze75.hdr"/>
             <composite_data value="Analyze75.img"/>
             <composite_data value="Analyze75.t2m"/>
         </param>
     </xml>
     <xml name="infile_imzml">
-        <param name="infile" value="" ftype="imzml">
+        <param name="infile" value="infile_imzml" ftype="imzml">
             <composite_data value="Example_Continuous.imzML"/>
             <composite_data value="Example_Continuous.ibd"/>
         </param>
     </xml>
     <xml name="processed_infile_imzml">
-        <param name="infile" value="" ftype="imzml">
+        <param name="infile" value="processed_infile_imzml" ftype="imzml">
             <composite_data value="Example_Processed.imzML"/>
             <composite_data value="Example_Processed.ibd"/>
         </param>

--- a/tools/cardinal/quality_report.xml
+++ b/tools/cardinal/quality_report.xml
@@ -976,7 +976,7 @@ if (npeaks > 0){
     </outputs>
     <tests>
         <test>
-            <param name="infile" value="" ftype="imzml">
+            <param name="infile" value="Example_Processed" ftype="imzml">
                 <composite_data value="Example_Processed.imzML"/>
                 <composite_data value="Example_Processed.ibd"/>
             </param>

--- a/tools/cardinal/segmentation.xml
+++ b/tools/cardinal/segmentation.xml
@@ -381,7 +381,7 @@ if (npeaks > 0 && sum(is.na(spectra(msidata)))==0)
             <output name="pixeloutput" file="classes_ssc.tabular"/>
         </test>
         <test>
-            <param name="infile" value="" ftype="imzml">
+            <param name="infile" value="preprocessing_results3" ftype="imzml">
                 <composite_data value="preprocessing_results3.imzml"/>
                 <composite_data value="preprocessing_results3.ibd"/>
             </param>

--- a/tools/cardinal/spectra_plots.xml
+++ b/tools/cardinal/spectra_plots.xml
@@ -610,7 +610,7 @@ if (ncol(msidata)>0 & nrow(msidata) >0){
             <output name="plots" file="Plot_processed.pdf" compare="sim_size"/>
         </test>
         <test>
-        <param name="infile" value="" ftype="imzml">
+        <param name="infile" value="preprocessing_results1" ftype="imzml">
             <composite_data value="preprocessing_results1.imzml"/>
             <composite_data value="preprocessing_results1.ibd"/>
         </param>


### PR DESCRIPTION
These tools pass all of their tests one by one but fail shed-tools parallel testing because a lot of the test inputs have the same value attribute as each other ("") but are different datasets.