### PR TITLE
openms: also detect oom for C++ tools

### DIFF
--- a/tools/openms/macros.xml
+++ b/tools/openms/macros.xml
@@ -20,6 +20,7 @@
   </xml>
   <xml name="stdio">
     <stdio>
+      <regex match="std::bad_alloc" level="fatal_oom" description="Could not allocate memory"/>
       <regex match="Could not allocate metaspace" level="fatal_oom" description="Java memory Exception"/>
       <regex match="Cannot create VM thread" level="fatal_oom" description="Java memory Exception"/>
       <regex match="qUncompress: could not allocate enough memory to uncompress data" level="fatal_oom" description="Java memory Exception"/>


### PR DESCRIPTION
I remember that agressive error checkking is not an option, so I added only this one.