### PR TITLE
msconvert: improve error detection

### DIFF
--- a/tools/msconvert/msconvert.xml
+++ b/tools/msconvert/msconvert.xml
@@ -1,4 +1,4 @@
-<tool id="msconvert" name="msconvert" version="@VERSION@.1">
+<tool id="msconvert" name="msconvert" version="@VERSION@.2">
   <description>Convert and/or filter mass spectrometry files</description>
   <macros>
       <import>msconvert_macros.xml</import>
@@ -6,6 +6,9 @@
   <requirements>
       <container type="docker">chambm/pwiz-skyline-i-agree-to-the-vendor-licenses:@FULL_VERSION@</container>
   </requirements>
+  <stdio>
+    <regex match="Error" source="stderr" level="fatal" description="Could not convert. Check stderr." />
+  </stdio>
   <expand macro="msconvertCommand" />
   <inputs>
       <param format="mzml,mzxml,mz5,mgf,ms2,thermo.raw,raw,wiff,wiff.tar,agilentbrukeryep.d.tar,agilentmasshunter.d.tar,brukerbaf.d.tar,brukertdf.d.tar,watersmasslynx.raw.tar" name="input" type="data" label="Input unrefined MS data" />

--- a/tools/msconvert/msconvert.xml
+++ b/tools/msconvert/msconvert.xml
@@ -7,7 +7,7 @@
       <container type="docker">chambm/pwiz-skyline-i-agree-to-the-vendor-licenses:@FULL_VERSION@</container>
   </requirements>
   <stdio>
-    <regex match="Error" source="stderr" level="fatal" description="Could not convert. Check stderr." />
+    <regex match="Error writing run" source="stderr" level="fatal" description="Could not convert. Check stderr." />
   </stdio>
   <expand macro="msconvertCommand" />
   <inputs>

--- a/tools/msconvert/msconvert_macros.xml
+++ b/tools/msconvert/msconvert_macros.xml
@@ -39,8 +39,7 @@
       ln -s '$data_processing.precursor_refinement.input_ident' '$input_ident_name' &&
     #end if
 
-
-    CAN_SUDO=\$(sudo -n -l 2> /dev/null; echo \$?) &&
+    CAN_SUDO=\$(sudo -n -l > /dev/null 2> /dev/null; echo $?) &&
     if [ "\$CAN_SUDO" -eq "0" ]; then
         uid=`id -u` &&
         gid=`id -g` &&    


### PR DESCRIPTION
msconvert wrote an incomplete file had exit code 0 and wrote the following to stderr. I think this should be a tool error

```
000d:err:menubuilder:init_xdg error looking up the desktop directory
0037:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
0037:err:winediag:nodrv_CreateWindow Make sure that your X server is running and that $DISPLAY is set correctly.
0037:err:ole:apartment_createwindowifneeded CreateWindow failed with error 183
0037:err:ole:apartment_createwindowifneeded CreateWindow failed with error 0
0037:err:ole:apartment_createwindowifneeded CreateWindow failed with error 0
000b:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
000b:err:winediag:nodrv_CreateWindow Make sure that your X server is running and that $DISPLAY is set correctly.
0035:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
0035:err:winediag:nodrv_CreateWindow Make sure that your X server is running and that $DISPLAY is set correctly.
0035:err:setupapi:create_dest_file failed to create L"C:\\windows\\system32\\mscoree.dll" (error=80)
003f:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
003f:err:winediag:nodrv_CreateWindow Make sure that your X server is running and that $DISPLAY is set correctly.
Could not load wine-gecko. HTML rendering will be disabled.
0044:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
0044:err:winediag:nodrv_CreateWindow Make sure that your X server is running and that $DISPLAY is set correctly.
0044:err:setupapi:create_dest_file failed to create L"C:\\windows\\system32\\mscoree.dll" (error=80)
0046:err:winediag:nodrv_CreateWindow Application tried to create a window, but no driver could be loaded.
0046:err:winediag:nodrv_CreateWindow Make sure that your X server is running and that $DISPLAY is set correctly.
Could not load wine-gecko. HTML rendering will be disabled.
wine: configuration in '/tmp/7240861.1.usva28/tmp.YnNKW8MLfl' has been updated.
0009:err:combase:RoGetActivationFactory Failed to find library for L"Windows.Foundation.Diagnostics.AsyncCausalityTracer"
Error writing run 1 in "180714_NJ_Bastida_ALP195.raw":
[RawFileImpl::setCurrentController()] Instrument index not available for requested device
Parameter name: instrumentIndex
```

All the lower case `"error"` should be OK. But for sure we could use a more specific regex.

furthermore somehow the sudo output redirection did not work locally.
I hope that the current form covers all cases.