### PR TITLE
define TMPDIR

### DIFF
--- a/tools/bumbershoot/idpassemble.xml
+++ b/tools/bumbershoot/idpassemble.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<tool id="idpassemble" name="idpAssemble" version="@VERSION@.0">
+<tool id="idpassemble" name="idpAssemble" version="@VERSION@.1">
     <description>Merge IDPicker databases from single files into a merged database, and filters the result at PSM/spectrum/peptide/protein/gene levels.</description>
     <macros>
         <import>macros.xml</import>
@@ -11,6 +11,7 @@
     </stdio>
     <command>
 <![CDATA[
+        export TMPDIR=\${TMPDIR:-.};
         #if len($input) < 2
         cp '${input}' output &&
         #end if


### PR DESCRIPTION
another weekly CI failure

```
Error: [executePairwiseFileMergerTask] 7ff6b3982700 error merging "/tmp/tmpxhfzqacn/files/a/6/3/dataset_a63d3a58-3a13-47cb-aff8-ad9c56df2d60.dat" and "/tmp/tmpxhfzqacn/files/3/4/a/dataset_34a363b4-da1c-4063-b08d-666fc69dc6c5.dat": boost::filesystem::temp_directory_path: Not a directory

Error:
Unhandled exception: [executePairwiseFileMergerTask] error merging "/tmp/tmpxhfzqacn/files/a/6/3/dataset_a63d3a58-3a13-47cb-aff8-ad9c56df2d60.dat" and "/tmp/tmpxhfzqacn/files/3/4/a/dataset_34a363b4-da1c-4063-b08d-666fc69dc6c5.dat": boost::filesystem::temp_directory_path: Not a directory
```