### PR TITLE
Update Mycoplasma ids

### DIFF
--- a/tools/dbbuilder/tool-data/uniprot_taxons.loc.sample
+++ b/tools/dbbuilder/tool-data/uniprot_taxons.loc.sample
@@ -14,7 +14,7 @@ Apis mellifera (Honeybee)	7460
 Mycobacterium tuberculosis H37Rv (MTB) [Not complete proteome]	83332
 Mycoplasma orale [Not complete proteome]	2121
 Mycoplasma hyorhinis	2100
-Mycoplasma arginini	2094
-Mycoplasma fermentans	2115
+Mycoplasma arginini	1188236
+Mycoplasma fermentans	496833
 Mycoplasma hominis	2098
 Acholeplasma laidlawii	2148


### PR DESCRIPTION
The ids of _Mycoplasma arginini_ and _M. fermentans_ have been updated by alternative ones corresponding to different strains. The previous ids pointed to defective Uniprot entries which caused the Protein database downloader doesn't yield any result.