### PR TITLE
read_mztab is refactored

### DIFF
--- a/tools/pyteomics/mztab2tsv.xml
+++ b/tools/pyteomics/mztab2tsv.xml
@@ -66,7 +66,7 @@
                 <assert_contents><has_text text="PSM_ID"/></assert_contents>
             </output>
             <output name="out_sml" ftype="tabular">
-                <assert_contents><has_text text="&quot;&quot;"/></assert_contents>
+                <assert_contents><has_n_lines n="0"/></assert_contents>
             </output>
         </test>
         <test expect_num_outputs="4">

--- a/tools/pyteomics/mztab2tsv.xml
+++ b/tools/pyteomics/mztab2tsv.xml
@@ -60,7 +60,7 @@
                 <assert_contents><has_text text="accession"/></assert_contents>
             </output>
             <output name="out_pep" ftype="tabular">
-                <assert_contents><has_text text="&quot;&quot;"/></assert_contents>
+                <assert_contents><has_n_lines n="0"/></assert_contents>
             </output>
             <output name="out_psm" ftype="tabular">
                 <assert_contents><has_text text="PSM_ID"/></assert_contents>

--- a/tools/pyteomics/mztab_reader.py
+++ b/tools/pyteomics/mztab_reader.py
@@ -9,43 +9,17 @@ from pyteomics.mztab import MzTab
 
 def read_mztab(input_path, output_path):
     """
-    Read mztab file
+    Read and process mztab file
     """
     mztab = MzTab(input_path)
-    if mztab.variant == 'P':
-        return read_mztab_p(mztab, output_path)
-    elif mztab.variant == 'M':
-        return read_mztab_m(mztab, output_path)
-
-
-def read_mztab_p(mztab, output_path):
-    """
-    Processing mztab "P"
-    """
     mtd = pd.DataFrame.from_dict(mztab.metadata, orient='index')
     mtd.to_csv(os.path.join(output_path, "mtd.tsv"), sep="\t")
-    prt = mztab.protein_table
-    prt.to_csv(os.path.join(output_path, "prt.tsv"), sep="\t")
-    pep = mztab.peptide_table
-    pep.to_csv(os.path.join(output_path, "pep.tsv"), sep="\t")
-    psm = mztab.spectrum_match_table
-    psm.to_csv(os.path.join(output_path, "psm.tsv"), sep="\t")
-    sml = mztab.small_molecule_table
-    sml.to_csv(os.path.join(output_path, "sml.tsv"), sep="\t")
-
-
-def read_mztab_m(mztab, output_path):
-    """
-    Processing mztab "M"
-    """
-    mtd = pd.DataFrame.from_dict(mztab.metadata, orient='index')
-    mtd.to_csv(os.path.join(output_path, "mtd.tsv"), sep="\t")
-    sml = mztab.small_molecule_table
-    sml.to_csv(os.path.join(output_path, "sml.tsv"), sep="\t")
-    smf = mztab.small_molecule_feature_table
-    smf.to_csv(os.path.join(output_path, "smf.tsv"), sep="\t")
-    sme = mztab.small_molecule_evidence_table
-    sme.to_csv(os.path.join(output_path, "sme.tsv"), sep="\t")
+    for name, tab in mztab:
+        if not tab.empty:
+            tab.to_csv(os.path.join(output_path, f"{name.lower()}.tsv"), sep="\t")
+        else:
+            with open(os.path.join(output_path, f"{name.lower()}.tsv"), "w") as empty_tsv:
+                pass
 
 
 if __name__ == "__main__":

--- a/tools/pyteomics/mztab_reader.py
+++ b/tools/pyteomics/mztab_reader.py
@@ -18,7 +18,7 @@ def read_mztab(input_path, output_path):
         if not tab.empty:
             tab.to_csv(os.path.join(output_path, f"{name.lower()}.tsv"), sep="\t")
         else:
-            with open(os.path.join(output_path, f"{name.lower()}.tsv"), "w") as empty_tsv:
+            with open(os.path.join(output_path, f"{name.lower()}.tsv"), "w"):
                 pass
 
 


### PR DESCRIPTION
Refactored `read_mztab` to write an empty `tsv` file instead of a file with an empty string when some table is missing. To avoid a lot of repeating `if` conditions iteration over the tables is now done with `__iter__` method of `MzTab` class from pyteomics.