### PR TITLE
Update SearchGUI to 4.0.12 & PeptideShaker to 2.0.9

### DIFF
--- a/tools/peptideshaker/README.rst
+++ b/tools/peptideshaker/README.rst
@@ -27,13 +27,14 @@ This can then be fed to the PeptideShaker tool which merges the results and perf
 General Requirements
 --------------------
 
-To avoid out of memory errors you should set the maximum heapspace for java processes as the default is most likely too small. For example, to set this in your shell:
+To avoid out of memory errors you may need to set the maximum heapspace for java processes if the default is too small for the data you are going to process (4gb for SearchGUI, 1GB for PeptideShaker).
+For example, to set this in your shell:
 
-    export _JAVA_OPTIONS='-Xmx1500M'
+    export _JAVA_OPTIONS='-Xmx8192m'
 
 On some systems you may also need to adjust the amount of memory available for class definitions in addition to the maximum heapspace. For example:
 
-	export _JAVA_OPTIONS='-Xmx1500M -XX:MaxPermSize=256M'
+	export _JAVA_OPTIONS='-Xmx8192m -XX:MaxPermSize=1024m'
 
 It is also possible to set this on a per tool basis using advanced features of the galaxy job config system.
 
@@ -52,7 +53,7 @@ For more help on installing Mono please see http://www.mono-project.com/download
 Note
 ----
 
-- Requires Galaxy release v16.01 or later.
+- Requires Galaxy release v20.01 or later.
 
 See:
 

--- a/tools/peptideshaker/macros_basic.xml
+++ b/tools/peptideshaker/macros_basic.xml
@@ -10,10 +10,10 @@
         </stdio>
     </xml>
     <token name="@SEARCHGUI_MAJOR_VERSION@">4</token>
-    <token name="@SEARCHGUI_VERSION@">4.0.7</token>
+    <token name="@SEARCHGUI_VERSION@">4.0.12</token>
     <token name="@SEARCHGUI_VERSION_SUFFIX@">0</token>
-    <token name="@PEPTIDESHAKER_VERSION@">2.0.5</token>
-    <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">3</token>
+    <token name="@PEPTIDESHAKER_VERSION@">2.0.9</token>
+    <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">0</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1186/1471-2105-12-70</citation>

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -22,6 +22,8 @@
 
         mkdir output;
         mkdir output_reports;
+        mkdir temp_folder;
+        mkdir log_folder;
         cwd=`pwd`;
         export HOME=\$cwd;
 
@@ -63,7 +65,8 @@
             -fasta_file "\$cwd/input_fasta_file.fasta"
             -output_folder \$cwd/output
             -id_params ./SEARCHGUI_IdentificationParameters.par
-
+            -temp_folder \$cwd/temp_folder
+            -log \$cwd/log_folder
             -threads "\${GALAXY_SLOTS:-12}"
 
             #if $searchgui_advanced.searchgui_advanced_selector == 'advanced'


### PR DESCRIPTION
SearchGUI updated to v4.0.12
PeptideShaker updated to v2.0.9

SearchGUI now configures temp and log folders into the working directory.