### PR TITLE
some fixes for searchgui and peptideshaker

### DIFF
--- a/tools/peptideshaker/fasta_cli.xml
+++ b/tools/peptideshaker/fasta_cli.xml
@@ -11,7 +11,6 @@
     <expand macro="stdio" />
     <command>
 <![CDATA[
-        #set $temp_stderr = "fasta_cli_stderr"
         #set $output_db_name = $input_database.display_name.replace(".fasta", "") + $database_processing_options.decoy_file_tag.value + ".fasta"
 
         mkdir output &&
@@ -25,9 +24,8 @@
         ###########################################
 
         echo 'Creating decoy database.' &&
-        searchgui -Djava.awt.headless=true eu.isas.searchgui.cmd.FastaCLI --exec_dir="./bin/" -temp_folder `pwd` -in '${input_database.display_name}' -decoy -decoy_flag $database_processing_options.decoy_tag -suffix $database_processing_options.decoy_type -decoy_suffix $database_processing_options.decoy_file_tag 2>> $temp_stderr &&
-        mv '${output_db_name}' output &&
-        cat $temp_stderr 2>&1;
+        searchgui -Djava.awt.headless=true eu.isas.searchgui.cmd.FastaCLI --exec_dir="./bin/" -temp_folder `pwd` -in '${input_database.display_name}' -decoy -decoy_flag $database_processing_options.decoy_tag -suffix $database_processing_options.decoy_type -decoy_suffix $database_processing_options.decoy_file_tag &&
+        mv '${output_db_name}' output
 ]]>
     </command>
     <inputs>

--- a/tools/peptideshaker/ident_params.xml
+++ b/tools/peptideshaker/ident_params.xml
@@ -12,7 +12,6 @@
     <expand macro="stdio" />
     <command>
 <![CDATA[
-        #set $temp_stderr = "searchgui_stderr"
         #set $bin_dir = "bin"
 
         mkdir output;
@@ -20,13 +19,12 @@
         export HOME=\$cwd;
 
 
-        echo "" > $temp_stderr &&
 
         echo 'running Identification Parameters CLI' &&
         #####################################################
         ## generate IdentificationParameters for SearchGUI ##
         #####################################################
-        (searchgui eu.isas.searchgui.cmd.IdentificationParametersCLI
+        searchgui eu.isas.searchgui.cmd.IdentificationParametersCLI
             --exec_dir="./bin/"
             -out './IdentificationParametersOutput.par'
 
@@ -614,10 +612,6 @@
             #end if
                 -fasta_target_decoy 0
                 -fasta_decoy_file_tag $advanced_options.database_processing_options.decoy_file_tag
-
-        2> $temp_stderr) &&
-
-        cat $temp_stderr 2>&1;
 ]]>
     </command>
     <inputs>

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -17,15 +17,12 @@
         #from datetime import datetime
         #set $exp_str = "Galaxy_Experiment_%s" % datetime.now().strftime("%Y%m%d%H%M%s")
         #set $samp_str = "Sample_%s" % datetime.now().strftime("%Y%m%d%H%M%s")
-        #set $temp_stderr = "peptideshaker_stderr"
         #set $bin_dir = "bin"
         #set $exporting_followup_boolean = False
 
         mkdir output_reports &&
         cwd=`pwd` &&
         export HOME=\$cwd &&
-
-        echo "" > $temp_stderr &&
 
         ln -s '$searchgui_input' searchgui_input.zip &&
 
@@ -64,7 +61,7 @@
         ######################
         ## PeptideShakerCLI ##
         ######################
-        (peptide-shaker -Djava.awt.headless=true eu.isas.peptideshaker.cmd.PeptideShakerCLI
+        peptide-shaker -Djava.awt.headless=true eu.isas.peptideshaker.cmd.PeptideShakerCLI
             -gui 0
             -temp_folder \$cwd/PeptideShakerCLI
             -log \$cwd/resources
@@ -182,8 +179,6 @@
             #end if
         #end if
 
-        2>> $temp_stderr)
-
         ## If the user chose to zip the results but also export reports out of the zip, we have to unzip them
         #if $exporting_options.zip_conditional.zip_output_boolean == 'zip' and $exporting_options.zip_conditional.export_reports_when_zip and (len(output_reports_list)>0 or $exporting_followup_boolean):
             ## This unzipping command creates a reports folder into the current folder!
@@ -238,6 +233,10 @@
             #if '11' in $output_reports_list:
                 && find \$cwd/output_reports -name '*Extended_PSM_Report.txt' -exec bash -c 'mv "$0" "psmx.txt"' {} \;
             #end if
+            ## the last ; is removed from the generated command line
+            ## thus we need to make sure that the above `find ... -exec ... \;`
+            ## is not the last command
+            && true
         #end if
 
         ## Moving followup analysis to the root folder (it is necessary if zip option was not chosen, or it was chosen but also exporting out of the zip)
@@ -259,7 +258,6 @@
                 && mv \$cwd/output_reports/inclusion_list.txt \$cwd/inclusion_list.txt
             #end if
         #end if
-        && cat $temp_stderr 2>&1;
 ]]>
     </command>
     <inputs>

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -17,7 +17,6 @@
         #import os
         #set $exp_str = "Galaxy_Experiment_%s" % datetime.now().strftime("%Y%m%d%H%M%s")
         #set $samp_str = "Sample_%s" % datetime.now().strftime("%Y%m%d%H%M%s")
-        #set $temp_stderr = "searchgui_stderr"
         #set $bin_dir = "bin"
 
         mkdir output;
@@ -26,8 +25,6 @@
         mkdir log_folder;
         cwd=`pwd`;
         export HOME=\$cwd;
-
-        echo "" > $temp_stderr &&
 
         ## echo the search engines to run (single quotes important because X!Tandem)
         echo '$search_engines_options.engines';
@@ -59,7 +56,7 @@
         ## Search CLI ##
         ################
         echo 'running search gui' &&
-        (searchgui -Djava.awt.headless=true eu.isas.searchgui.cmd.SearchCLI
+        searchgui -Djava.awt.headless=true eu.isas.searchgui.cmd.SearchCLI
             --exec_dir="\$cwd/${bin_dir}"
             -spectrum_files \$cwd
             -fasta_file "\$cwd/input_fasta_file.fasta"
@@ -150,17 +147,13 @@
             ## mgf and database in output
             -output_data 1
 
-        2>> $temp_stderr)
+        &&
+
+        mv output/searchgui_out.zip searchgui_out.zip
 
         &&
 
-        (mv output/searchgui_out.zip searchgui_out.zip 2>> $temp_stderr)
-
-        &&
-
-        (zip -u searchgui_out.zip searchgui.properties 2>> $temp_stderr);
-
-        cat $temp_stderr 2>&1;
+        zip -u searchgui_out.zip searchgui.properties
 ]]>
     </command>
     <inputs>


### PR DESCRIPTION
1. remove stderr redirection

in case of

```
command 2>> $temp_stderr &&
.... &&
cat $temp_stderr 2>&1;
```

stderr is swallowed if command fails.
this was the case for PS, FC, and IP

in case of

```
command 2>> $temp_stderr &&
.... ;
cat $temp_stderr 2>&1;
```

the last cat is executed even if the command fails.
the exit code of the command line is then the exit
code of the cat, i.e. the tool will always be counted
successful, even if everything fails.

2. fix peptideshaker find exec constructs

Galaxy removes the last ';' from the generated command line.
thus we need to make sure that the last `find ... -exec ... \;`
is not the last command.

3. remove some unnecessay parentheses

TODO

- [ ] make IP and FC versions equal to SG version (except for tool version suffix `+galaxyX`)?
