### PR TITLE
MaxQuant: append error log files to stderr

### DIFF
--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -1,4 +1,4 @@
-<tool id="maxquant" name="MaxQuant" version="@VERSION@+galaxy4">
+<tool id="maxquant" name="MaxQuant" version="@VERSION@+galaxy5">
     <macros>
         <xml name="output" token_format="tabular" token_label="default description" token_name="default">
             <data format="@FORMAT@" label="@LABEL@ for ${on_string}" name="@NAME@">
@@ -14,6 +14,7 @@
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
+    trap ">&2 find combined/proc/ -name '*.error.txt' -exec bash -c 'cat \"\$0\"' {} \;" EXIT;
     #import re
     maxquant -c mqpar.xml 2>/dev/null  ## MQ writes success of creation to stderr
     #if 'config' in $output_opts.output:

--- a/tools/maxquant_mqpar/maxquant_mqpar.xml
+++ b/tools/maxquant_mqpar/maxquant_mqpar.xml
@@ -1,4 +1,4 @@
-<tool id="maxquant_mqpar" name="MaxQuant (using mqpar.xml)" version="@VERSION@">
+<tool id="maxquant_mqpar" name="MaxQuant (using mqpar.xml)" version="@VERSION@+galaxy1">
     <macros>
         <xml name="output" token_format="tabular" token_label="default description" token_name="default">
             <data format="@FORMAT@" label="@LABEL@ for ${on_string}" name="@NAME@">
@@ -14,6 +14,7 @@
     </macros>
     <expand macro="requirements"/>
     <command detect_errors="exit_code"><![CDATA[
+    trap ">&2 find combined/proc/ -name '*.error.txt' -exec bash -c 'cat \"\$0\"' {} \;" EXIT;
     ## link galaxy datasets to filenames accepted by maxquant
     #import re
     #set names = [re.sub('@SUBSTITUTION_RX@', '_', str($n.element_identifier)) for $n in $input.infiles]


### PR DESCRIPTION


MaxQuant's error output seems pretty useless for users and admins:

E.g.

```
Unhandled Exception:
System.Exception: Exception during execution of external process: 27929
  at BaseLibS.Util.WorkDispatcher.ProcessSingleRunExternalProcess (System.Int32 taskIndex, System.Int32 threadIndex) [0x001a1] in <3fc1eb7cc45041de8ce7f41aa00f3311>:0
  at BaseLibS.Util.WorkDispatcher.DoWork (System.Int32 taskIndex, System.Int32 threadIndex) [0x0001e] in <3fc1eb7cc45041de8ce7f41aa00f3311>:0
  at BaseLibS.Util.WorkDispatcher.Work (System.Object threadIndex) [0x00054] in <3fc1eb7cc45041de8ce7f41aa00f3311>:0
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00025] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ThreadHelper.ThreadStart (System.Object obj) [0x0000f] in <7cd4deb8302a478d9d393f24754841da>:0
[ERROR] FATAL UNHANDLED EXCEPTION: System.Exception: Exception during execution of external process: 27929
  at BaseLibS.Util.WorkDispatcher.ProcessSingleRunExternalProcess (System.Int32 taskIndex, System.Int32 threadIndex) [0x001a1] in <3fc1eb7cc45041de8ce7f41aa00f3311>:0
  at BaseLibS.Util.WorkDispatcher.DoWork (System.Int32 taskIndex, System.Int32 threadIndex) [0x0001e] in <3fc1eb7cc45041de8ce7f41aa00f3311>:0
  at BaseLibS.Util.WorkDispatcher.Work (System.Object threadIndex) [0x00054] in <3fc1eb7cc45041de8ce7f41aa00f3311>:0
  at System.Threading.ThreadHelper.ThreadStart_Context (System.Object state) [0x00025] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ExecutionContext.RunInternal (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00071] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state, System.Boolean preserveSyncCtx) [0x00000] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ExecutionContext.Run (System.Threading.ExecutionContext executionContext, System.Threading.ContextCallback callback, System.Object state) [0x0002b] in <7cd4deb8302a478d9d393f24754841da>:0
  at System.Threading.ThreadHelper.ThreadStart (System.Object obj) [0x0000f] in <7cd4deb8302a478d9d393f24754841da>:0
```

But there are error file in combined/proc/ which contain more info, e.g.

```
id	0
start	15/03/2021 13:22:03
title	Testing_raw_files (4/6)
description	/gpfs1/work/songalax/galaxy/database/jobs_directory/000/107/107504/working/2016-04-05_NJ_Groundwater_5_1.raw.thermo.raw
error	/gpfs1/work/songalax/galaxy/database/jobs_directory/000/107/107504/working/2016-04-05_NJ_Groundwater_5_1.raw.thermo.raw_The file '/gpfs1/work/songalax/galaxy/database/jobs_directory/000/107/107504/working/2016-04-05_NJ_Groundwater_5_1.raw.thermo.raw' appears to be corrupt. Try to open it with vendor software. Error message: RunHeaderEx_  at MaxQuantPLibS.Basic.MaxQuantTasks.TestFile (System.Int32 taskIndex, System.String mqparFile) [0x00080] in <e0d3ea923fb542858289d68af3ae5a27>:0 _  at MaxQuantPLibS.Work.RawFileTester.Calculation (System.String[] args, BaseLibS.Util.Responder responder) [0x00009] in <e0d3ea923fb542858289d68af3ae5a27>:0 _  at MaxQuantPLibS.Work.MaxQuantWorkDispatcherUtil.PerformTask (System.Int32 taskType, System.String[] args, BaseLibS.Util.Responder responder) [0x00007] in <e0d3ea923fb542858289d68af3ae5a27>:0 _  at MaxQuantTask.Program.Function (System.String[] args, BaseLibS.Util.Responder responder) [0x00012] in <a9a7ab44566440088bf38b1365d644dc>:0 _  at Utils.Util.ExternalProcess.Run (System.String[] args, System.Boolean debug) [0x000af] in <13cd68fb3f5d4831b26fc0f070437c6f>:0
end	15/03/2021 13:22:04
```

Which contains the slightly more useful message: `2016-04-05_NJ_Groundwater_5_1.raw.thermo.raw' appears to be corrupt. Try to open it with vendor software.`

While this might still overwhelm end users its certainly useful for
admins (and they do not need to remember where the error are kept for
MaxQuant)


TODO: 

- [ ] does someone has raw files for testing? 
