### PR TITLE
update thermo converter to 1.3.4

### DIFF
--- a/tools/ThermoRawFileParser/test-data/really_small.indexed_mzML
+++ b/tools/ThermoRawFileParser/test-data/really_small.indexed_mzML
@@ -26,8 +26,8 @@
       </referenceableParamGroup>
     </referenceableParamGroupList>
     <softwareList count="1">
-      <software id="ThermoRawFileParser" version="1.3.3">
-        <cvParam cvRef="MS" accession="MS:1003145" name="ThermoRawFileParser" />
+      <software id="ThermoRawFileParser" version="1.3.4">
+        <cvParam cvRef="MS" accession="MS:1000799" value="ThermoRawFileParser" name="custom unreleased software tool" />
       </software>
     </softwareList>
     <instrumentConfigurationList count="1">
@@ -2695,78 +2695,78 @@
   </mzML>
   <indexList count="2">
     <index name="spectrum">
-      <offset idRef="controllerType=0 controllerNumber=1 scan=1">3680</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=2">8638</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=3">13470</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=4">18165</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=5">23275</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=6">27236</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=7">31849</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=8">36725</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=9">41067</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=10">45377</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=11">50593</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=12">55747</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=13">60215</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=14">64618</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=15">68778</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=16">73504</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=17">78052</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=18">82854</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=19">87446</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=20">91807</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=21">96591</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=22">100668</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=23">104729</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=24">108885</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=25">113860</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=26">118991</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=27">123304</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=28">127342</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=29">132138</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=30">136192</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=31">140294</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=32">144559</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=33">149090</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=34">153463</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=35">158870</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=37">163704</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=39">168004</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=40">172608</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=41">177642</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=42">182768</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=43">187467</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=44">191436</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=45">195870</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=46">200672</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=47">206011</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=50">210647</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=51">216058</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=52">221276</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=53">226017</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=54">231567</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=55">237114</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=56">241501</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=57">247221</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=58">252718</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=59">257835</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=60">263534</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=61">272252</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=63">281997</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=64">293023</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=65">304825</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=66">312583</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=67">324901</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=79">338860</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=88">354346</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=99">365556</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=100">371876</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=101">379207</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=1">3720</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=2">8678</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=3">13510</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=4">18205</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=5">23315</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=6">27276</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=7">31889</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=8">36765</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=9">41107</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=10">45417</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=11">50633</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=12">55787</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=13">60255</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=14">64658</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=15">68818</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=16">73544</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=17">78092</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=18">82894</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=19">87486</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=20">91847</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=21">96631</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=22">100708</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=23">104769</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=24">108925</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=25">113900</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=26">119031</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=27">123344</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=28">127382</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=29">132178</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=30">136232</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=31">140334</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=32">144599</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=33">149130</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=34">153503</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=35">158910</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=37">163744</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=39">168044</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=40">172648</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=41">177682</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=42">182808</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=43">187507</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=44">191476</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=45">195910</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=46">200712</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=47">206051</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=50">210687</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=51">216098</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=52">221316</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=53">226057</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=54">231607</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=55">237154</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=56">241541</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=57">247261</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=58">252758</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=59">257875</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=60">263574</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=61">272292</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=63">282037</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=64">293063</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=65">304865</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=66">312623</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=67">324941</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=79">338900</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=88">354386</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=99">365596</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=100">371916</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=101">379247</offset>
     </index>
     <index name="chromatogram">
-      <offset idRef="BasePeak_0">385537</offset>
+      <offset idRef="BasePeak_0">385577</offset>
     </index>
   </indexList>
-  <indexListOffset>388541</indexListOffset>
-  <fileChecksum>d17fa5e67c8f89705eec985e7029ba040ec4ff8c</fileChecksum>
+  <indexListOffset>388581</indexListOffset>
+  <fileChecksum>a22a375f0d68c090984a97ff9f12d0871ab4cb73</fileChecksum>
 </indexedmzML>

--- a/tools/ThermoRawFileParser/test-data/really_small.mzml
+++ b/tools/ThermoRawFileParser/test-data/really_small.mzml
@@ -25,8 +25,8 @@
     </referenceableParamGroup>
   </referenceableParamGroupList>
   <softwareList count="1">
-    <software id="ThermoRawFileParser" version="1.3.3">
-      <cvParam cvRef="MS" accession="MS:1003145" name="ThermoRawFileParser" />
+    <software id="ThermoRawFileParser" version="1.3.4">
+      <cvParam cvRef="MS" accession="MS:1000799" value="ThermoRawFileParser" name="custom unreleased software tool" />
     </software>
   </softwareList>
   <instrumentConfigurationList count="1">

--- a/tools/ThermoRawFileParser/test-data/really_small_ext.mzml
+++ b/tools/ThermoRawFileParser/test-data/really_small_ext.mzml
@@ -25,8 +25,8 @@
     </referenceableParamGroup>
   </referenceableParamGroupList>
   <softwareList count="1">
-    <software id="ThermoRawFileParser" version="1.3.3">
-      <cvParam cvRef="MS" accession="MS:1003145" name="ThermoRawFileParser" />
+    <software id="ThermoRawFileParser" version="1.3.4">
+      <cvParam cvRef="MS" accession="MS:1000799" value="ThermoRawFileParser" name="custom unreleased software tool" />
     </software>
   </softwareList>
   <instrumentConfigurationList count="1">

--- a/tools/ThermoRawFileParser/thermo_converter.xml
+++ b/tools/ThermoRawFileParser/thermo_converter.xml
@@ -1,7 +1,7 @@
 <tool id="thermo_raw_file_converter" name="Thermo" version="@TOOL_VERSION@+galaxy0" profile="20.05">
     <description>RAW file converter</description>
     <macros>
-        <token name="@TOOL_VERSION@">1.3.3</token>
+        <token name="@TOOL_VERSION@">1.3.4</token>
     </macros>
     <requirements>
         <requirement type="package" version="@TOOL_VERSION@">thermorawfileparser</requirement>


### PR DESCRIPTION
this includes a rollback of the underlying change that broke compatibility between some of the critical projects in this space (https://github.com/compomics/ThermoRawFileParser/wiki/ReleaseNotes)

+ regenerate test data in addition to version


I understand the failures except the one below. Could this be caused by the following entry in the release notes?

> Disable peak picking for specified MS levels



```
-      <offset idRef="controllerType=0 controllerNumber=1 scan=3">13470</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=4">18165</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=5">23275</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=6">27236</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=7">31849</offset>
-      <offset idRef="controllerType=0 controllerNumber=1 scan=8">36725</offset>
********
*SNIP *
********
+      <offset idRef="controllerType=0 controllerNumber=1 scan=58">252758</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=59">257875</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=60">263574</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=61">272292</offset>
+      <offset idRef="controllerType=0 controllerNumber=1 scan=63">282037</offset>
```