### PR TITLE
New eggnog release

### DIFF
--- a/tools/eggnog_mapper/eggnog_macros.xml
+++ b/tools/eggnog_mapper/eggnog_macros.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@VERSION@">2.0.1</token>
+   <token name="@VERSION@">2.1.2</token>
    <token name="@EGGNOG_DB_VERSION@">2.0</token>
     <!--
     # Versionning is super confusing:


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/469983/116807983-91f0e780-ab36-11eb-8a79-88f82a012bcb.png)

This seems to be a confusing release as well. Now version `Version 5.0.2 of the eggnog.db sqlite DB.` is needed?

Just putting out this PR, to see what happens and if anyone is interested to work on it.