### PR TITLE
Fix MS level filter

### DIFF
--- a/tools/msconvert/msconvert_macros.xml
+++ b/tools/msconvert/msconvert_macros.xml
@@ -166,7 +166,7 @@
       #end if
 
       #if $filtering.filter_ms_levels.do_ms_level_filter
-        --filter "msLevel [$filtering.filter_ms_levels.ms_level_from, $filtering.filter_ms_levels.ms_level_to]"
+        --filter "msLevel [$filtering.filter_ms_levels.ms_level_from,$filtering.filter_ms_levels.ms_level_to]"
       #end if
 
       #if str($filtering.polarity) != "false"


### PR DESCRIPTION
The option parser has a bug if there's a space in the MS level range, so `[2, 3]` is interpreted as only MS level 3, but `[2,3]` is levels 2 and 3. This is technically a bug in msconvert but it's easier to fix here.