### PR TITLE
Upgrade metaquantome to version 2.0.2

### DIFF
--- a/tools/metaquantome/macros.xml
+++ b/tools/metaquantome/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">2.0.1</token>
+    <token name="@TOOL_VERSION@">2.0.2</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>


### PR DESCRIPTION
This allows the viz module to handle column names starting with a digit.