### PR TITLE
Update MaxQuant 1.6.17.0

### DIFF
--- a/tools/maxquant/macros.xml
+++ b/tools/maxquant/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <macros>
     <token name="@VERSION@">1.6.17.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@VERSION_PTXQC@">1.0.10</token>
     <token name="@SUBSTITUTION_RX@">[^\w\-\s\.]</token>
     <token name="@TMT2PLEX@">

--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -493,7 +493,7 @@ short peptides are usually not unique in the protein database and therefore not 
                     <param name="lfqNormType" type="select" label="Normalization type"
                            multiple="false" help="">
                         <option value="0">None</option>
-                        <option value="1">Classic</option>
+                        <option value="1" selected="true">Classic</option>
                     </param>
                 </when>
                 <when value="reporter_ion_ms2">

--- a/tools/maxquant/test-data/03/config.yml
+++ b/tools/maxquant/test-data/03/config.yml
@@ -33,7 +33,7 @@
                 enzymes: [Trypsin/P]
                 enzymeMode: 0
                 lfqMode: 1
-                lfqNormType: 0
+                lfqNormType: 1
                 lfqMinEdgesPerNode: 3
                 lfqAvEdgesPerNode: 6
                 lfqMinRatioCount: 2

--- a/tools/maxquant/test-data/05/config.yml
+++ b/tools/maxquant/test-data/05/config.yml
@@ -38,7 +38,7 @@
                 enzymes: [Trypsin/P]
                 enzymeMode: 0
                 lfqMode: 1
-                lfqNormType: 0
+                lfqNormType: 1
                 lfqMinEdgesPerNode: 3
                 lfqAvEdgesPerNode: 6
                 lfqMinRatioCount: 2

--- a/tools/maxquant/test-data/05/mqpar.xml
+++ b/tools/maxquant/test-data/05/mqpar.xml
@@ -298,7 +298,7 @@
 			<centroidPosition>0</centroidPosition>
 			<diaQuantMethod>7</diaQuantMethod>
 			<diaFeatureQuantMethod>2</diaFeatureQuantMethod>
-			<lfqNormType>0</lfqNormType>
+			<lfqNormType>1</lfqNormType>
 			<diaTopNForQuant>10</diaTopNForQuant>
 			<diaMinMsmsIntensityForQuant>0</diaMinMsmsIntensityForQuant>
 			<diaTopMsmsIntensityQuantileForQuant>0.85</diaTopMsmsIntensityQuantileForQuant>


### PR DESCRIPTION
A parameter was changed from `lfqSkipNorm` to `lfqNormType` in 1.6.17.0. Default value for `lfqSkipNorm` in earlier MQ versions was `false` (Skip normalization). Default value in 1.6.17.0 for `lfqNormType` is `Classic`, which is equivalent to `lfqSkipNorm = false`. This PR changes the default selection of `lfqSkipNorm` to `Classic` in the Galaxy wrapper.