### PR TITLE
Fix MaxQuant 1.6.17.0

### DIFF
--- a/tools/maxquant/macros.xml
+++ b/tools/maxquant/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <macros>
     <token name="@VERSION@">1.6.17.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <token name="@VERSION_PTXQC@">1.0.10</token>
     <token name="@SUBSTITUTION_RX@">[^\w\-\s\.]</token>
     <token name="@TMT2PLEX@">

--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -458,7 +458,6 @@ short peptides are usually not unique in the protein database and therefore not 
                 <option value="4">Unspecific</option>
                 <option value="5">No digestion</option>
             </param>
-
             <conditional name="quant_method">
                 <param name="select_quant_method" type="select" label="Quantitation Methods"
                        help="Select a method if needed.">

--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -32,7 +32,11 @@
     #set names_with_ext = [($name if ($name).lower().endswith(str($input_opts.ftype)) else $name + str($input_opts.ftype)) for $name in $names]
     #for $target, $link in zip($infiles, $names_with_ext)
         &&
+        #if str($input_opts.ftype) == '.thermo.raw':
+        cp '$target' '$link'
+        #else:
         ln -s '$target' '$link'
+        #end if
     #end for
     &&
     python3 '$__tool_directory__/create_mqpar.py'


### PR DESCRIPTION
Thermo RAW files have some incompatibilities with soft links and the dotnet dependency. The workaround is to simply copy files instead of sym link them. Older MaxQuant versions (<=1.6.10.43) are not affected by this. Some Thermo DLLs were updated in 1.6.17.0 compared to 1.6.10.43, maybe the problem relies here.. (f.e. ThermoFisher.CommonCore.RawFileReader.dll 3.0.59.0 -> 5.0.0.38).