### PR TITLE
SG updated to v4.0.41 && PeptideShaker updated to v2.0.33.1

### DIFF
--- a/tools/peptideshaker/macros_basic.xml
+++ b/tools/peptideshaker/macros_basic.xml
@@ -14,7 +14,7 @@
     <token name="@SEARCHGUI_VERSION@">4.0.41</token>
     <token name="@SEARCHGUI_VERSION_SUFFIX@">0</token>
     <token name="@PEPTIDESHAKER_VERSION@">2.0.33</token>
-    <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">0</token>
+    <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">1</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1186/1471-2105-12-70</citation>

--- a/tools/peptideshaker/macros_basic.xml
+++ b/tools/peptideshaker/macros_basic.xml
@@ -13,7 +13,7 @@
     <token name="@SEARCHGUI_MAJOR_VERSION@">4</token>
     <token name="@SEARCHGUI_VERSION@">4.0.41</token>
     <token name="@SEARCHGUI_VERSION_SUFFIX@">0</token>
-    <token name="@PEPTIDESHAKER_VERSION@">2.0.29</token>
+    <token name="@PEPTIDESHAKER_VERSION@">2.0.33</token>
     <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">0</token>
     <xml name="citations">
         <citations>

--- a/tools/peptideshaker/macros_basic.xml
+++ b/tools/peptideshaker/macros_basic.xml
@@ -11,9 +11,9 @@
         </stdio>
     </xml>
     <token name="@SEARCHGUI_MAJOR_VERSION@">4</token>
-    <token name="@SEARCHGUI_VERSION@">4.0.33</token>
+    <token name="@SEARCHGUI_VERSION@">4.0.41</token>
     <token name="@SEARCHGUI_VERSION_SUFFIX@">0</token>
-    <token name="@PEPTIDESHAKER_VERSION@">2.0.25</token>
+    <token name="@PEPTIDESHAKER_VERSION@">2.0.29</token>
     <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">0</token>
     <xml name="citations">
         <citations>

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -38,7 +38,9 @@
         #if $optional_main_parameters.input_optional_identification_parameters:
             cp '${optional_main_parameters.input_optional_identification_parameters}' SEARCHGUI_IdentificationParameters.par &&
         #else:
-            jar xvf searchgui_input.zip SEARCHGUI_IdentificationParameters.par &&
+            ## Note that there will be just one .par file, the one (with unkown name) used thorought SG execution. We will rename it to a "standard" name
+            unzip -o searchgui_input.zip *.par &&
+            mv *.par SEARCHGUI_IdentificationParameters.par &&
         #end if
         ## Optional Fasta file
         #if $optional_main_parameters.input_fasta_file:
@@ -68,7 +70,7 @@
         ######################
         ## PeptideShakerCLI ##
         ######################
-        
+
         ## TODO: --exec_dir may not be needed anymore. To be tested further (and maybe removed from the Conda package).
 
         peptide-shaker -Djava.awt.headless=true eu.isas.peptideshaker.cmd.PeptideShakerCLI
@@ -188,12 +190,12 @@
                 #end if
             #end if
         #end if
-        
+
         ## Whilst non-blocking exception " /usr/local/share/peptide-shaker-2.0.25-0/resources/conf/paths.txt (Permission denied)"
         ## is fixed , we can avoid the process to be stopped by removing that message from the output
-        
+
         |   grep -v "resources/conf/paths.txt (Permission denied)"
-        
+
         ## If the user chose to zip the results but also export reports out of the zip, we have to unzip them
         #if $exporting_options.zip_conditional.zip_output_boolean == 'zip' and $exporting_options.zip_conditional.export_reports_when_zip and (len(output_reports_list)>0 or $exporting_followup_boolean):
             ## This unzipping command creates a reports folder into the current folder!

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -252,7 +252,7 @@
             <param name="engines" value="MetaMorpheus"/>
             <output name="searchgui_results" ftype="searchgui_archive">
                 <assert_contents>
-                    <has_size value="778597" delta="10000"/>
+                    <has_size value="798597" delta="10000"/>
                 </assert_contents>
             </output>
         </test>

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -180,7 +180,7 @@
         <!-- Search Engine Selection -->
         <section name="search_engines_options" expanded="true" title="Search Engine Options">
             <param name="engines" type="select" display="checkboxes" multiple="True" label="DB-Search Engines">
-                <help>Comet and Tide shouldn't both be selected since they use a similar algoritm. OMSSA may not work into isolated environments like containers. 
+                <help>Comet and Tide shouldn't both be selected since they use a similar algoritm. OMSSA might not work into isolated environments like containers. Ms Amanda may not work either when executed into isolated environments based on MacOS X.
                     MetaMorpheus only produce results when using mzML format.</help>
                 <option value="X!Tandem" selected="True">X!Tandem</option>
                 <option value="MSGF" selected="True">MS-GF+</option>
@@ -241,8 +241,8 @@
             <param name="engines" value="X!Tandem,MSGF,MyriMatch,Comet"/>
             <output name="searchgui_results" file="searchgui_tiny_result_default_4engines.zip" ftype="searchgui_archive" compare="sim_size" delta="30000" />
         </test>
-        
-        
+
+
         <!-- Test that search works with MetaMorpheus with default parameters works-->
         <!-- Test data has been taken from metamorpheus galaxy tool -->
         <test>
@@ -350,7 +350,7 @@ and the FASTA header must either contain no "|" characters (then the whole heade
 
     >generic[your tag]|[protein accession]|[protein description]
 
-    or 
+    or
 
     >generic[your tag]|[protein accession]
 

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -252,7 +252,7 @@
             <param name="engines" value="MetaMorpheus"/>
             <output name="searchgui_results" ftype="searchgui_archive">
                 <assert_contents>
-                    <has_size value="798597" delta="10000"/>
+                    <has_size value="778597" delta="10000"/>
                 </assert_contents>
             </output>
         </test>


### PR DESCRIPTION
SG:
Last updates on SG application and Conda package have fixed diverse errors running DirectTag, MsAmanda, Myrimatch and OMSSA.
Last MsAmanda versions are based on .NET Core, and some issues generating bundles with .NET Core 5 for macosx have caused errors leading to remove it from the Conda package for macosx until .NET Core 6 has been released.
Many other minor updates.

PS:
PeptideShaker bugfix managing searchgui files with different parameter name than the previously fixed one.