### PR TITLE
Fix image not showing in proteomiqon_peptidespectrummatching

### DIFF
--- a/tools/proteomiqon_peptidespectrummatching/proteomiqon_peptidespectrummatching.xml
+++ b/tools/proteomiqon_peptidespectrummatching/proteomiqon_peptidespectrummatching.xml
@@ -179,7 +179,7 @@ Given raw a MS run in the mzite format, this tool iterates accross all recorded 
 With this it is possible to query the peptide data base for every precursor ion mass +/- a tolerance (which defines the so called 'search space') and retrieve peptides that are 
 theoretical candidates for a match. For each of the peptide candidates we create an theoretical spectrum in silico and compare it to the measured MS/MS scan.
 
-.. image:: PSM.png
+.. image:: $PATH_TO_IMAGES/PSM.png
             :width: 768pt
             :height: 563pt
 


### PR DESCRIPTION
This PR attempts to fix the image not showing in the help section of the Proteomiqon PeptideSpectrumMatching tool, found here: https://usegalaxy.eu/root?tool_id=proteomiqon_peptidespectrummatching

To solve the issue, I took a look at https://github.com/galaxyproject/tools-iuc/blob/master/tools/bedtools/slopBed.xml and saw that they prefixed images with $PATH_TO_IMAGES/ so I followed that practice.

If this is not the cause of the image not showing up, please let me know.

