### PR TITLE
Thermo raw file parser outputname

### DIFF
--- a/tools/ThermoRawFileParser/thermo_converter.xml
+++ b/tools/ThermoRawFileParser/thermo_converter.xml
@@ -1,4 +1,4 @@
-<tool id="thermo_raw_file_converter" name="Thermo" version="@TOOL_VERSION@+galaxy0" profile="20.05">
+<tool id="thermo_raw_file_converter" name="Thermo" version="@TOOL_VERSION@+galaxy1" profile="20.05">
     <description>RAW file converter</description>
     <macros>
         <token name="@TOOL_VERSION@">1.3.4</token>
@@ -85,7 +85,7 @@ ThermoRawFileParser.sh
         </param>
     </inputs>
     <outputs>
-        <data name="output" format="mzml" label="${tool.name} on ${on_string}">
+        <data name="output" format="mzml" label="${($input_file.name.rsplit('.',1)[0] if $input_file.name.lower().endswith('.raw') else $input_file.name)}.${('mgf' if $format_cond.output_format == '0' else 'mzml')}">
             <change_format>
                 <when input="format_cond.output_format" value="0" format="mgf"/>
                 <!-- <when input="format_cond.output_format" value="3" format="parquet"/> -->

--- a/tools/validate_fasta_database/validate_fasta_database.xml
+++ b/tools/validate_fasta_database/validate_fasta_database.xml
@@ -1,4 +1,4 @@
-<tool id="validate_fasta_database" name="Validate FASTA Database" version="0.1.4">
+<tool id="validate_fasta_database" name="Validate FASTA Database" version="0.1.5">
     <requirements>
         <requirement type="package" version="1.0">validate-fasta-database</requirement>
     </requirements>
@@ -19,19 +19,18 @@
     <inputs>
         <param type="data" name="inFasta" format="fasta" label="Select input FASTA dataset"/>
         <param type="boolean" name="crashIfInvalid"
-               label="Fail job if invalid FASTA headers detected?"
-               value="false"/>
+               truevalue="true" falsevalue="false" checked="false"
+               label="Fail job if invalid FASTA headers detected?"/>
         <param type="boolean" name="checkIsProtein"
+               truevalue="true" falsevalue="false" checked="true"
                label="Ensure that sequence is a valid amino acid sequence?"
-               help="Checks that sequence only contains the 20 essential amino
-                acids (and optional non-standard AAs), and checks that is not DNA or RNA"
-               value="true"/>
+               help="Checks that sequence only contains the 20 essential amino acids (and optional non-standard AAs), and checks that is not DNA or RNA"/>
         <param type="text" name="customLetters" value=""
                label="Optional: add one letter codes for any non-standard amino acids that you are using. "
                help="Anything that is not an upper case letter [A-Z] will be ignored."/>
         <param type="boolean" name="checkHasAccession"
-               label="Only pass sequences with accession numbers?"
-               value="false"/>
+               truevalue="true" falsevalue="false" checked="false"
+               label="Only pass sequences with accession numbers?"/>
         <param type="integer" name="minimumLength"
                label="Minimum length for sequences to pass"
                value="0"/>
@@ -44,6 +43,7 @@
         <!-- test general filtering -->
         <test>
             <param name="inFasta" value="fastaFilteringTest_IN.fasta"/>
+            <param name="checkIsProtein" value="false"/>
             <output name="goodFastaOut" file="fastaFilteringTest_OUT1.fasta" />
             <output name="badFastaOut" file="fastaFilteringTest_OUT2.fasta" />
         </test>


### PR DESCRIPTION
@subinamehta requested the the input spectrum name be preserved when using ThermoRawConverter.  
This will remove a .raw or .RAW extension from the input name and append either a .mgf or .mzml as the output name.