### PR TITLE
Update mz_to_sqlite.xml

### DIFF
--- a/tools/mz_to_sqlite/mz_to_sqlite.xml
+++ b/tools/mz_to_sqlite/mz_to_sqlite.xml
@@ -1,7 +1,7 @@
-<tool id="mz_to_sqlite" name="mz to sqlite" version="2.0.4+galaxy1">
+<tool id="mz_to_sqlite" name="mz to sqlite" version="2.1.1+galaxy0">
     <description>Extract mzIdentML and associated proteomics datasets into a SQLite DB</description>
     <requirements>
-        <requirement type="package" version="2.0.4">mztosqlite</requirement>
+        <requirement type="package" version="2.1.1">mztosqlite</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" level="fatal" description="Error Running mz_to_sqlite" />


### PR DESCRIPTION
Version 2.1.1  mzToSQLite fills the encoded_sequence field of tables peptides and spectrum_counts required in the MVP visualization app.