### PR TITLE
'mzxml' and 'mzml' filetypes must be specified in lower case

### DIFF
--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -431,7 +431,7 @@ short peptides are usually not unique in the protein database and therefore not 
 
 
         <repeat name="paramGroups" title="Parameter Group" min="1" default="1">
-            <param type="data" format="thermo.raw,mzXML,mzML" name="files" label="Infiles" multiple="true"
+            <param type="data" format="thermo.raw,mzxml,mzml" name="files" label="Infiles" multiple="true"
                    help="Only select infiles matching the filetype specified in the input options."/>
             <param type="integer" name="maxMissedCleavages"
                    label="missed cleavages" value="2"
@@ -1008,9 +1008,9 @@ This tool is a wrapper for MaxQuant v@VERSION@. The current version of the wrapp
 
 **Input files**
 
-- Thermo raw, mzML, mzXMLfiles (in parameter group section)
+- Thermo raw, mzML, or mzXML files (in parameter group section)
 
-    - The datatype of all files has to be either 'thermo.raw', 'mzML' or 'mzXML'. Make sure to specify the correct datatype either during upload to Galaxy or afterwards (edit attributes --> datatypes)
+    - The datatype of all files has to be either 'thermo.raw', 'mzml' or 'mzxml'. Make sure to specify the correct datatype either during upload to Galaxy or afterwards (edit attributes --> datatypes)
 - Fasta file: specify parse rules according to your fasta file (header). Some examples for different fasta headers:  
 
                 ::

--- a/tools/maxquant/maxquant_mqpar.xml
+++ b/tools/maxquant/maxquant_mqpar.xml
@@ -67,8 +67,8 @@
         <conditional name="input_opts">
             <param name="ftype" type="select" label="choose the type of your input files">
                 <option value=".thermo.raw">thermo.raw</option>
-                <option value=".mzxml">mzXML</option>
-                <option value=".mzml">mzML</option>
+                <option value=".mzxml">mzxml</option>
+                <option value=".mzml">mzml</option>
             </param>
             <when value=".thermo.raw"> 
                 <param multiple="true" name="infiles" type="data"
@@ -77,12 +77,12 @@
             </when>
             <when value=".mzxml">
                 <param multiple="true" name="infiles" type="data"
-                       format="mzXML" label="mzXML Files"
+                       format="mzxml" label="mzXML Files"
                        help="Specify one or more mzXML files" />
             </when>
             <when value=".mzml">
                 <param multiple="true" name="infiles" type="data"
-                       format="mzML" label="mzML Files"
+                       format="mzml" label="mzML Files"
                        help="Specify one or more mzML files" />
             </when>
         </conditional>
@@ -191,8 +191,8 @@ This tool is a wrapper for MaxQuant v@VERSION@. It gets its search parameters fr
 
 **Input files**
 
-- Thermo raw file or mzXML file
-    - The datatype has to be 'thermo.raw' or 'mzXML'. Make sure to specify the correct datatype either during upload to Galaxy or afterwards (edit attributes --> datatypes)
+- Thermo raw file, mzML, or mzXML files
+    - The datatype has to be 'thermo.raw', 'mzml', or 'mzxml'. Make sure to specify the correct datatype either during upload to Galaxy or afterwards (edit attributes --> datatypes)
 - mqpar.xml: 
     - MaxQuant parameters will be taken from the provided mqpar.xml file. This parameter file MUST be created using the same version of MaxQuant as is used by this tool. The correct version of MaxQuant can be obtained via the bioconda channel for the conda package manager.
 


### PR DESCRIPTION
'mzxml' and 'mzml' filetypes must be specified in lower case for inputs to function properly in the workflow editor; I got orange input nodes rather than green when I tried to link an mzxml output to the inputs of `maxquant` or `maxquant_mqpar`.

To circumvent this issue, I had to hack the tool xml files in a local Galaxy; then the editor worked, and (luckily) I could upload the workflow to production Galaxies (e.g., UseGalaxy.eu) and they can be run successfully (they can even be edited so long as the connection made in an "offline Galaxy" is not severed).  This PR makes the case of the inputs correct, in my view.

Thank you.

attn: @npinter