### PR TITLE
Add required_files for maxquant an maxquant_mqpar

### DIFF
--- a/tools/maxquant/macros.xml
+++ b/tools/maxquant/macros.xml
@@ -96,6 +96,11 @@
             <requirement type="package" version="1.32">tar</requirement>
         </requirements>
     </xml>
+    <xml name="required_files">
+        <required_files>
+            <include path="mqparam.py" />
+        </required_files>
+    </xml>
     <xml name="ptxqc">
         <configfile name="qr_yaml">
             PTXQC:

--- a/tools/maxquant/macros.xml
+++ b/tools/maxquant/macros.xml
@@ -98,6 +98,8 @@
     </xml>
     <xml name="required_files">
         <required_files>
+            <include path="create_mqpar.py" />
+            <include path="modify_mqpar.py" />
             <include path="mqparam.py" />
         </required_files>
     </xml>

--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -13,6 +13,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
+    <expand macro="required_files"/>
     <command detect_errors="exit_code"><![CDATA[
     #import re
     maxquant -c mqpar.xml 2>/dev/null  ## MQ writes success of creation to stderr

--- a/tools/maxquant/maxquant_mqpar.xml
+++ b/tools/maxquant/maxquant_mqpar.xml
@@ -13,6 +13,7 @@
         <import>macros.xml</import>
     </macros>
     <expand macro="requirements"/>
+    <expand macro="required_files"/>
     <command detect_errors="exit_code"><![CDATA[
     ## link galaxy datasets to filenames accepted by maxquant
     #import re


### PR DESCRIPTION
Both maxquant and maxquant_mqpar call on the python scripts create_mqpar.py and modify_mqpar.py.  Both scripts require another file, mqparam.py but pulsar will not copy this file because it is not referred to by name in the tool command.