### PR TITLE
Remove protein modification options

### DIFF
--- a/tools/pepquery/macros.xml
+++ b/tools/pepquery/macros.xml
@@ -1,6 +1,6 @@
  <macros>
     <token name="@TOOL_VERSION@">1.6.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="modifications">
         <option value="1">HexNAc of T (203.07937251951) modaa</option>
         <option value="2">HexNAc of S (203.07937251951) modaa</option>
@@ -13,7 +13,7 @@
         <option value="9">S-nitrosylation (28.99016359229) modaa</option>
         <option value="10">TMT 6-plex of K (229.16293213472) modaa</option>
         <option value="11">Propionyl of peptide N-term heavy (59.03627926124) modn_peptide</option>
-        <option value="12">Formylation of protein N-term (27.99491461956) modn_protein</option>
+        <!-- <option value="12">Formylation of protein N-term (27.99491461956) modn_protein</option> -->
         <option value="13">TMT 10-plex of K+6 (235.18306116152) modaa</option>
         <option value="14">TMT 11-plex of K+6 (235.18306116152) modaa</option>
         <option value="15">TMT 10-plex of K+8 (237.17713094832) modaa</option>
@@ -21,9 +21,9 @@
         <option value="17">Diiodination of Y (251.79329593586) modaa</option>
         <option value="18">TMT 10-plex of K+4 (233.18803911764) modaa</option>
         <option value="19">ICPL10 of peptide N-term (115.06669973029) modn_peptide</option>
-        <option value="20">Amidation of the protein C-term (-0.9840155826899988) modc_protein</option>
+        <!-- <option value="20">Amidation of the protein C-term (-0.9840155826899988) modc_protein</option> -->
         <option value="21">Acetylation of peptide N-term (42.0105646837) modn_peptide</option>
-        <option value="22">Palmitoylation of protein N-term (238.22966558166) modn_protein</option>
+        <!-- <option value="22">Palmitoylation of protein N-term (238.22966558166) modn_protein</option> -->
         <option value="23">ICAT-O (227.12699141827) modaa</option>
         <option value="24">TMT 2-plex of peptide N-term (225.15583272792) modn_peptide</option>
         <option value="25">TMT 11-plex of K+8 (237.17713094832) modaa</option>
@@ -33,7 +33,7 @@
         <option value="29">Acetylation of K (42.0105646837) modaa</option>
         <option value="30">Dimethylation of peptide N-term 2H(6) 13C(2) (36.075670278260006) modn_peptide</option>
         <option value="31">ICPL0 of K (105.02146372057) modaa</option>
-        <option value="32">Trimethylation of protein N-term A (42.04695019242) modn_protein</option>
+        <!-- <option value="32">Trimethylation of protein N-term A (42.04695019242) modn_protein</option> -->
         <option value="33">Thioacyl of peptide N-term (87.99828574784) modn_peptide</option>
         <option value="34">Trideuterated Methyl Ester of R (17.034480301330003) modaa</option>
         <option value="35">ICPL4 of peptide N-term (109.04657070349) modn_peptide</option>
@@ -71,12 +71,12 @@
         <option value="67">Farnesylation of C (204.18780076968) modaa</option>
         <option value="68">Trimethylation of K (42.04695019242) modaa</option>
         <option value="69">iTRAQ 8-plex of peptide N-term (304.19903946116) modn_peptide</option>
-        <option value="70">FormylMet of protein N-term (159.03539953255) modn_protein</option>
+        <!-- <option value="70">FormylMet of protein N-term (159.03539953255) modn_protein</option> -->
         <option value="71">Dimethylation of K (28.03130012828) modaa</option>
         <option value="72">mTRAQ of K 13C(3) 15N (144.1020624208) modaa</option>
         <option value="73">Carboxymethylation of C (58.00547930326) modaa</option>
         <option value="74">Guanidination of peptide N-term (42.02179807374) modn_peptide</option>
-        <option value="75">Acetylation of protein N-term (42.0105646837) modn_protein</option>
+        <!-- <option value="75">Acetylation of protein N-term (42.0105646837) modn_protein</option> -->
         <option value="76">Trimethylation of R (42.04695019242) modaa</option>
         <option value="77">Pyrolidone from E (-18.0105646837) modnaa_peptide</option>
         <option value="78">Dimethylation of R (28.03130012828) modaa</option>
@@ -112,7 +112,7 @@
         <option value="108">TMT 10-plex of K (229.16293213472) modaa</option>
         <option value="109">Oxidation of C (15.99491461956) modaa</option>
         <option value="110">Amidation of the peptide C-term (-0.9840155826899988) modc_peptide</option>
-        <option value="111">Carbamilation of protein N-term (43.00581365643) modn_protein</option>
+        <!-- <option value="111">Carbamilation of protein N-term (43.00581365643) modn_protein</option> -->
         <option value="112">ICPL6 of K (111.04159274737) modaa</option>
         <option value="113">Propionamide of peptide N-term (71.03711378471) modn_peptide</option>
         <option value="114">Phosphorylation of Y (79.96633052074999) modaa</option>


### PR DESCRIPTION
protein modifications aren't working in pepquery, removing them to reduce chance of user error.