### PR TITLE
updating the unrecognized argument genepred to be recognized

### DIFF
--- a/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
+++ b/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
@@ -14,7 +14,7 @@
             $input_trans.translate
         #end if
         #if $input_trans.itype in ['genome', 'metagenome']:
-            $input_trans.genepred
+            --genepred $input_trans.genepred
         #end if
 
         ## Diamond option


### PR DESCRIPTION
Updating the argument genepred used for Metagenome and Genome type of sequences, in order to be recognized by the command line of the tool