### PR TITLE
Import re module.

### DIFF
--- a/tools/metanovo/metanovo.xml
+++ b/tools/metanovo/metanovo.xml
@@ -7,7 +7,7 @@
   </requirements>
   <macros>
     <token name="@TOOL_VERSION@">1.9.4</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <token name="@SUBSTITUTION_RX@">[^\w\-\.]</token>
     <import>macros_modifications.xml</import>
   </macros>

--- a/tools/metanovo/metanovo.xml
+++ b/tools/metanovo/metanovo.xml
@@ -13,6 +13,7 @@
   </macros>
   <command>
     <![CDATA[
+      #import re
       #set $mgf_dir = 'mgf_files'
       #set $fasta_dir = 'fasta_file'
       #set fasta_name = re.sub('@SUBSTITUTION_RX@', '_', str($input_fasta.element_identifier))


### PR DESCRIPTION
This `import re` line was left out duplicating changes from the testing environment for the initial MetaNovo commit earlier today.