### PR TITLE
Fix symlinking of collection files.

### DIFF
--- a/tools/metanovo/metanovo.xml
+++ b/tools/metanovo/metanovo.xml
@@ -7,7 +7,7 @@
   </requirements>
   <macros>
     <token name="@TOOL_VERSION@">1.9.4</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <token name="@SUBSTITUTION_RX@">[^\w\-\.]</token>
     <import>macros_modifications.xml</import>
   </macros>
@@ -22,13 +22,13 @@
       ln -s '$input_fasta' '$fasta_dir/$fasta_name' &&
 
       #if $input_type.type == "collection"
-      #set mgf_names = [re.sub('@SUBSTITUTION_RX@', '_', str($n.element_identifier)) for $n in $input_type.input_mgf_collection]
-      #for $mgf_name in $mgf_names:
-      ln -s '$input' '$mgf_dir/$mgf_name' &&
+      #for $input_mgf_item in $input_type.input_mgf_collection:
+      #set mgf_name = re.sub('@SUBSTITUTION_RX@', '_', str($input_mgf_item.element_identifier))
+      ln -s '$input_mgf_item' '$mgf_dir/$mgf_name' &&
       #end for
       #else
       #set mgf_name = re.sub('@SUBSTITUTION_RX@', '_', str($input_type.input_mgf.element_identifier))
-      ln -s '$input_mgf' '$mgf_dir/$mgf_name' &&
+      ln -s '$input_type.input_mgf' '$mgf_dir/$mgf_name' &&
       #end if
 
       cat $metanovo_config > config.sh &&


### PR DESCRIPTION
After updating the initial PR to replace certain characters in input filenames, I failed to retest the collection input logic (MetaNovo can run on multiple files), and it was broken.

This makes a good case for adding automated tests soon.