### PR TITLE
bump eggnog

### DIFF
--- a/tools/eggnog_mapper/data_manager_eggnog_mapper/data_manager/data_manager_eggnog.xml
+++ b/tools/eggnog_mapper/data_manager_eggnog_mapper/data_manager/data_manager_eggnog.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_eggnog" name="EggNOG DB Download" version="@VERSION@+galaxy1" tool_type="manage_data" profile="18.09">
+<tool id="data_manager_eggnog" name="EggNOG DB Download" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="18.09">
     <description>eggnog data</description>
     <macros>
         <import>eggnog_macros.xml</import>

--- a/tools/eggnog_mapper/data_manager_eggnog_mapper_abspath/data_manager/data_manager_eggnog.xml
+++ b/tools/eggnog_mapper/data_manager_eggnog_mapper_abspath/data_manager/data_manager_eggnog.xml
@@ -1,4 +1,4 @@
-<tool id="data_manager_eggnog_abspath" name="EggNOG DB Download" version="@VERSION@+galaxy1" tool_type="manage_data" profile="18.09">
+<tool id="data_manager_eggnog_abspath" name="EggNOG DB Download" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" tool_type="manage_data" profile="18.09">
     <description>eggnog data to a specified directory</description>
     <macros>
         <import>eggnog_macros.xml</import>

--- a/tools/eggnog_mapper/eggnog_macros.xml
+++ b/tools/eggnog_mapper/eggnog_macros.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <macros>
-   <token name="@VERSION@">2.1.6</token>
+   <token name="@TOOL_VERSION@">2.1.8</token>
+   <token name="@VERSION_SUFFIX@">2.1.8</token>
    <token name="@EGGNOG_DB_VERSION@">5.0.2</token>
     <!--
     # DB versionning was super confusing for eggnog-mapper 2.0.x:
@@ -18,7 +19,7 @@
     </xml>
     <xml name="requirements">
         <requirements>
-            <requirement type="package" version="@VERSION@">eggnog-mapper</requirement>
+            <requirement type="package" version="@TOOL_VERSION@">eggnog-mapper</requirement>
         </requirements>
     </xml>
     <xml name="version_command">

--- a/tools/eggnog_mapper/eggnog_macros.xml
+++ b/tools/eggnog_mapper/eggnog_macros.xml
@@ -64,4 +64,10 @@ python '${__tool_directory__}/data_manager_eggnog.py' --config_file '$out_file' 
             </output>
         </test>
     </xml>
+    <xml name="stdout_assertion">
+        <assert_stdout>
+            <has_line line="#  emapper-@TOOL_VERSION@"/>
+            <has_line line="FINISHED"/>
+        </assert_stdout>
+    </xml>
 </macros>

--- a/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
+++ b/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
@@ -1,4 +1,4 @@
-<tool id="eggnog_mapper" name="eggNOG Mapper" version="@VERSION@+galaxy2">
+<tool id="eggnog_mapper" name="eggNOG Mapper" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@">
     <description>functional sequence annotation by orthology</description>
     <macros>
         <import>eggnog_macros.xml</import>

--- a/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
+++ b/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
@@ -319,14 +319,15 @@
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <param name="input" value="Nmar_0135.fa" ftype="fasta"/>
             <param name="eggnog_data" value="@EGGNOG_DB_VERSION@"/>
             <param name="no_annot" value="true"/>
             <param name="no_file_comments" value="true"/>
             <output name="seed_orthologs" file="DIA_nlim.emapper.seed_orthologs" ftype="tabular" compare="sim_size"/>
+            <expand macro="stdout_assertion"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="input" value="Nmar_0135.fa" ftype="fasta"/>
             <param name="eggnog_data" value="@EGGNOG_DB_VERSION@"/> <!-- not passed in test, but required for test to work -->
             <param name="report_orthologs" value="true"/>
@@ -334,8 +335,9 @@
             <output name="seed_orthologs" file="DIA_nlim.emapper.seed_orthologs" ftype="tabular" compare="sim_size"/>
             <output name="annotations" file="DIA_nlim.emapper.annotations" ftype="tabular" compare="sim_size"/>
             <output name="annotations_orthologs" file="DIA_nlim.emapper.annotations_orthologs" ftype="tabular"/>
+            <expand macro="stdout_assertion"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="input" value="Nmar_0135.fa" ftype="fasta"/>
             <param name="eggnog_data" value="@EGGNOG_DB_VERSION@"/> <!-- not passed in test, but required for test to work -->
             <param name="report_orthologs" value="true"/>
@@ -346,8 +348,9 @@
             <output name="seed_orthologs" file="scoped.emapper.seed_orthologs" ftype="tabular" compare="sim_size"/>
             <output name="annotations" file="scoped.emapper.annotations" ftype="tabular" compare="sim_size"/>
             <output name="annotations_orthologs" file="scoped.emapper.annotations_orthologs" ftype="tabular"/>
+            <expand macro="stdout_assertion"/>
         </test>
-        <test>
+        <test expect_num_outputs="3">
             <param name="input" value="Nmar_0135.fa" ftype="fasta"/>
             <param name="eggnog_data" value="@EGGNOG_DB_VERSION@"/> <!-- not passed in test, but required for test to work -->
             <section name="seed_ortho_options">
@@ -361,6 +364,7 @@
             <output name="seed_orthologs" file="DIA_nlim.emapper.seed_orthologs" ftype="tabular" compare="sim_size"/>
             <output name="annotations" file="DIA_nlim.emapper.annotations" ftype="tabular" compare="sim_size"/>
             <output name="annotations_orthologs" file="DIA_nlim.emapper.annotations_orthologs" ftype="tabular"/>
+            <expand macro="stdout_assertion"/>
         </test>
         <!-- not enabled as it requires a specific .db file, hard to minimize -->
         <!--test>

--- a/tools/eggnog_mapper/eggnog_mapper/test-data/DIA_nlim.emapper.annotations_orthologs
+++ b/tools/eggnog_mapper/eggnog_mapper/test-data/DIA_nlim.emapper.annotations_orthologs
@@ -1,3 +1,3 @@
 #query	orth_type	species	orthologs
 Nmar_0135	one2one	Marine Group I thaumarchaeote SCGC AB-629-I23(1131266)	*ARWQ01000003_gene1537
-Nmar_0135	one2one	Nitrosopumilus maritimus SCM1(436308)	*Nmar_0135
+Nmar_0135	seed	Nitrosopumilus maritimus SCM1(436308)	*Nmar_0135

--- a/tools/eggnog_mapper/eggnog_mapper/test-data/scoped.emapper.annotations_orthologs
+++ b/tools/eggnog_mapper/eggnog_mapper/test-data/scoped.emapper.annotations_orthologs
@@ -1,3 +1,3 @@
 #query	orth_type	species	orthologs
 Nmar_0135	one2one	Marine Group I thaumarchaeote SCGC AB-629-I23(1131266)	*ARWQ01000003_gene1537
-Nmar_0135	one2one	Nitrosopumilus maritimus SCM1(436308)	*Nmar_0135
+Nmar_0135	seed	Nitrosopumilus maritimus SCM1(436308)	*Nmar_0135


### PR DESCRIPTION
user reported an error where eggnog reported that a `diamond blastp`
call failed. when executing the failing call I get

```
diamond v2.0.11.149 (C) Max Planck Society for the Advancement of Science
Documentation, support and updates available at http://www.diamondsearch.org
Please cite: http://dx.doi.org/10.1038/s41592-021-01101-x Nature Methods (2021)

Scoring parameters: (Matrix=BLOSUM62 Lambda=0.267 K=0.041 Penalties=11/1)
Temporary directory: No such file or directory
Error: Error opening temporary file /gpfs1/work/songalax/galaxy/database/jobs_directory/000/155/155782/working/emappertmp_dmdn_OnTm_q/diamond-tmp-i7fCqW
```

Release notes indicate that a tmpdir related bug was fixed:

https://github.com/eggnogdb/eggnog-mapper/releases

overall 2.1.7 and 2.1.8 seem to be a bugfix releases