### PR TITLE
regex find/replace: use format_source for output

### DIFF
--- a/tools/regex_find_replace/regex.xml
+++ b/tools/regex_find_replace/regex.xml
@@ -48,26 +48,26 @@
   </outputs>
   <tests>
     <test>
-      <param name="input" value="find1.txt"/>
+      <param name="input" value="find1.txt" ftype="txt"/>
       <param name="pattern" value="(T\w+)"/>
       <param name="replacement" value="\1 \1" />
-      <output name="out_file1" file="replace1.txt"/>
+      <output name="out_file1" file="replace1.txt" ftype="txt"/>
     </test>
     <test>
-      <param name="input" value="find1.txt"/>
+      <param name="input" value="find1.txt" ftype="txt"/>
       <param name="pattern" value="f"/>
       <param name="replacement" value="'&quot;" />
-      <output name="out_file1" file="replace2.txt"/>
+      <output name="out_file1" file="replace2.txt" ftype="txt"/>
     </test>
     <test>
-      <param name="input" value="find1.txt"/>
+      <param name="input" value="find1.txt" ftype="txt"/>
       <param name="checks_0|pattern" value="a test file"/>
       <param name="checks_0|replacement" value="a file named #{input_name}" />
       <param name="checks_1|pattern" value="see here"/>
       <param name="checks_1|replacement" value="see #{input_name}" />
       <param name="checks_2|pattern" value="see (find1).txt"/>
       <param name="checks_2|replacement" value="see \1" />
-      <output name="out_file1" file="replace3.txt"/>
+      <output name="out_file1" file="replace3.txt" ftype="txt"/>
     </test>
   </tests>
   <help>

--- a/tools/regex_find_replace/regex.xml
+++ b/tools/regex_find_replace/regex.xml
@@ -1,4 +1,4 @@
-<tool id="regex1" name="Regex Find And Replace" version="1.0.2" profile="21.01">
+<tool id="regex1" name="Regex Find And Replace" version="1.0.3" profile="21.01">
   <description></description>
   <requirements>
     <requirement type="package" version="3.7">python</requirement>
@@ -44,7 +44,7 @@
     </repeat>
   </inputs>
   <outputs>
-    <data format="input" name="out_file1" metadata_source="input"/>
+    <data format_source="input" name="out_file1" metadata_source="input"/>
   </outputs>
   <tests>
     <test>

--- a/tools/regex_find_replace/regex_tabular.xml
+++ b/tools/regex_find_replace/regex_tabular.xml
@@ -1,4 +1,4 @@
-<tool id="regexColumn1" name="Column Regex Find And Replace" version="1.0.2" profile="21.01">
+<tool id="regexColumn1" name="Column Regex Find And Replace" version="1.0.3" profile="21.01">
   <description></description>
   <requirements>
     <requirement type="package" version="3.7">python</requirement>
@@ -46,7 +46,7 @@
     </repeat>
   </inputs>
   <outputs>
-    <data format="input" name="out_file1" metadata_source="input" />
+    <data format_source="input" name="out_file1" metadata_source="input" />
   </outputs>
   <tests>
     <test>
@@ -54,14 +54,14 @@
       <param name="field" value="2" />
       <param name="pattern" value="moo"/>
       <param name="replacement" value="cow" />
-      <output name="out_file1" file="replace_tabular_1.txt"/>
+      <output name="out_file1" file="replace_tabular_1.txt" ftype="tabular"/>
     </test>
     <test>
       <param name="input" value="find_tabular_1.txt" ftype="tabular" />
       <param name="field" value="1" />
       <param name="pattern" value="moo"/>
       <param name="replacement" value="cow" />
-      <output name="out_file1" file="replace_tabular_2.txt"/>
+      <output name="out_file1" file="replace_tabular_2.txt" ftype="tabular"/>
     </test>
   </tests>
   <help>


### PR DESCRIPTION
Version 1.0.2 of the tool uses format="input" in its output declaration. This creates an output with data type "input". I figure, the intention is instead to create an output with the same data type as the input. This should fix it, right?

Incidentally, this same error can currently be found in the Tool XML documentation.