### PR TITLE
fix the uniprot URL

### DIFF
--- a/tools/dbbuilder/dbbuilder.xml
+++ b/tools/dbbuilder/dbbuilder.xml
@@ -1,4 +1,4 @@
-<tool id="dbbuilder" name="Protein Database Downloader" version="0.3.2">
+<tool id="dbbuilder" name="Protein Database Downloader" version="0.3.3">
     <description></description>
     <requirements>
         <requirement type="package" version="1.20.1">wget</requirement>
@@ -13,8 +13,11 @@
         <!-- ftp://ftp.ncbi.nih.gov/refseq/H_sapiens/mRNA_Prot/human.protein.faa.gz-->
     <command>
 <![CDATA[
+        #if $source.set:
+            #set $modified_set = '&' + str($source.set) 
+        #end if
         #if $source.from == "uniprot"
-            #set $url = 'http://www.uniprot.org/uniprot/?query=taxonomy:"' + str($source.taxon) + '"' + str($source.set) + str($source.reviewed) + '&force=yes&format=fasta' + str($source.include_isoform)
+            #set $url = 'http://rest.uniprot.org/uniprot/search?query=taxonomy_id:"' + str($source.taxon) + '"' + str($modified_set) + str($source.reviewed) + '&format=fasta' + str($source.include_isoform)
             #set $type = "direct"
         #elif $source.from == "cRAP"
             ##set $url = "ftp://ftp.thegpm.org/fasta/cRAP/crap.fasta"
@@ -51,7 +54,8 @@
     </command>
     <inputs>
         <conditional name="source">
-            <param name="from" type="select" label="Download from" help="Select database source. cRAP acts as a database for common MS contaminants. UniProtKB is a cross species collection of functional protein databases">
+            <param name="from" type="select" label="Download from"
+                help="Select database source. cRAP acts as a database for common MS contaminants. UniProtKB is a cross species collection of functional protein databases">
                 <option value="uniprot">UniProtKB</option>
                 <option value="cRAP">cRAP (contaminants)</option>
                 <option value="HMP">Human Microbiome Project body sites</option>
@@ -66,10 +70,11 @@
                         <column name="value" index="1" />
                     </options>
                 </param>
-                <param name="reviewed" type="select" help="UniProtKB/TrEMBL (unreviewed)is a large, automatically annotated database- may contain redundant sequences, but there is a higher chance peptides will be identified. UniProtKB/Swiss-Prot (reviewed) is a smaller, manually annotated database- less of a chance peptides will be identified but less sequence redundancy">
+                <param name="reviewed" type="select"
+                    help="UniProtKB/TrEMBL (unreviewed)is a large, automatically annotated database- may contain redundant sequences, but there is a higher chance peptides will be identified. UniProtKB/Swiss-Prot (reviewed) is a smaller, manually annotated database- less of a chance peptides will be identified but less sequence redundancy">
                     <option value="+">UniProtKB</option>
-                    <option value="+reviewed%3Ayes">UniProtKB/Swiss-Prot (reviewed only)</option>
-                    <option value="+reviewed%3Ano">UniProtKB/TrEMBL (unreviewed only)</option>
+                    <option value="+reviewed%3Atrue">UniProtKB/Swiss-Prot (reviewed only)</option>
+                    <option value="+reviewed%3Afalse">UniProtKB/TrEMBL (unreviewed only)</option>
                     <sanitizer>
                         <valid>
                             <add value="%"/>
@@ -77,15 +82,16 @@
                     </sanitizer>
                 </param>
                 <param name="set" type="select" label="Proteome Set">
-                    <option value="+">Any</option>
-                    <option value="+keyword%3a1185" selected="true">Reference Proteome Set</option>
+                    <option value="">Any</option>
+                    <option value="keyword%3aKW-1185" selected="true">Reference Proteome Set</option>
                     <sanitizer>
                         <valid>
                             <add value="%"/>
                         </valid>
                     </sanitizer>
                 </param>
-                <param name="include_isoform" type="boolean" truevalue="&amp;include=yes" falsevalue="" label="Include isoform data" help="several different forms of a given protein are incorporated into database" />
+                <param name="include_isoform" type="boolean" truevalue="&amp;includeIsoform=true" falsevalue="" 
+                    label="Include isoform data" help="several different forms of a given protein are incorporated into database" />
             </when>
             <when value="cRAP" />
             <when value="HMP">


### PR DESCRIPTION
@jj-umn @bernt-matthias we have a problem here. The uniprot API has changed. 

I could not quickly find a way to download everything in one go. It seems the UniProt API is limited to 500 entries per request.
And other things have also changed. 