### PR TITLE
fixed case of mzxml and mzml in maxquant_mqpar tool

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,7 +2,7 @@ name: Galaxy Tool Linting and Tests for push and PR
 on: [push, pull_request]
 env:
   GALAXY_FORK: galaxyproject
-  GALAXY_BRANCH: release_22.01
+  GALAXY_BRANCH: release_22.05
   MAX_CHUNKS: 4
   MAX_FILE_SIZE: 1M
 concurrency:

--- a/tools/maxquant/macros.xml
+++ b/tools/maxquant/macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" ?>
 <macros>
     <token name="@VERSION@">1.6.17.0</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@VERSION_SUFFIX@">5</token>
     <token name="@VERSION_SUFFIX_MQPAR@">1</token>
     <token name="@VERSION_PTXQC@">1.0.10</token>
     <token name="@SUBSTITUTION_RX@">[^\w\-\s\.]</token>

--- a/tools/maxquant/macros.xml
+++ b/tools/maxquant/macros.xml
@@ -2,7 +2,7 @@
 <macros>
     <token name="@VERSION@">1.6.17.0</token>
     <token name="@VERSION_SUFFIX@">4</token>
-    <token name="@VERSION_SUFFIX_MQPAR@">0</token>
+    <token name="@VERSION_SUFFIX_MQPAR@">1</token>
     <token name="@VERSION_PTXQC@">1.0.10</token>
     <token name="@SUBSTITUTION_RX@">[^\w\-\s\.]</token>
     <token name="@TMT2PLEX@">

--- a/tools/maxquant/maxquant.xml
+++ b/tools/maxquant/maxquant.xml
@@ -1,4 +1,4 @@
-<tool id="maxquant" name="MaxQuant" version="@VERSION@+galaxy@VERSION_SUFFIX@">
+<tool id="maxquant" name="MaxQuant" version="@VERSION@+galaxy@VERSION_SUFFIX@" profile="21.05">
     <macros>
         <xml name="output" token_format="tabular" token_label="default description" token_name="default">
             <data format="@FORMAT@" label="@LABEL@ for ${on_string}" name="@NAME@">
@@ -15,6 +15,8 @@
     <expand macro="requirements"/>
     <expand macro="required_files"/>
     <command detect_errors="exit_code"><![CDATA[
+    ## this is needed to avoid dotnet from crashing, in a newer dotnet version we can remove that
+    export COMPlus_EnableDiagnostics=0 &&
     #import re
     maxquant -c mqpar.xml 2>/dev/null  ## MQ writes success of creation to stderr
 

--- a/tools/maxquant/maxquant_mqpar.xml
+++ b/tools/maxquant/maxquant_mqpar.xml
@@ -68,8 +68,8 @@
         <conditional name="input_opts">
             <param name="ftype" type="select" label="choose the type of your input files">
                 <option value=".thermo.raw">thermo.raw</option>
-                <option value=".mzxml">mzXML</option>
-                <option value=".mzml">mzML</option>
+                <option value=".mzxml">mzxml</option>
+                <option value=".mzml">mzml</option>
             </param>
             <when value=".thermo.raw"> 
                 <param multiple="true" name="infiles" type="data"
@@ -78,12 +78,12 @@
             </when>
             <when value=".mzxml">
                 <param multiple="true" name="infiles" type="data"
-                       format="mzXML" label="mzXML Files"
+                       format="mzxml" label="mzXML Files"
                        help="Specify one or more mzXML files" />
             </when>
             <when value=".mzml">
                 <param multiple="true" name="infiles" type="data"
-                       format="mzML" label="mzML Files"
+                       format="mzml" label="mzML Files"
                        help="Specify one or more mzML files" />
             </when>
         </conditional>
@@ -193,7 +193,7 @@ This tool is a wrapper for MaxQuant v@VERSION@. It gets its search parameters fr
 **Input files**
 
 - Thermo raw file or mzXML file
-    - The datatype has to be 'thermo.raw' or 'mzXML'. Make sure to specify the correct datatype either during upload to Galaxy or afterwards (edit attributes --> datatypes)
+    - The datatype has to be 'thermo.raw' or 'mzxml'. Make sure to specify the correct datatype either during upload to Galaxy or afterwards (edit attributes --> datatypes)
 - mqpar.xml: 
     - MaxQuant parameters will be taken from the provided mqpar.xml file. This parameter file MUST be created using the same version of MaxQuant as is used by this tool. The correct version of MaxQuant can be obtained via the bioconda channel for the conda package manager.
 

--- a/tools/maxquant/maxquant_mqpar.xml
+++ b/tools/maxquant/maxquant_mqpar.xml
@@ -1,4 +1,4 @@
-<tool id="maxquant_mqpar" name="MaxQuant (using mqpar.xml)" version="@VERSION@+galaxy@VERSION_SUFFIX_MQPAR@">
+<tool id="maxquant_mqpar" name="MaxQuant (using mqpar.xml)" version="@VERSION@+galaxy@VERSION_SUFFIX_MQPAR@" profile="21.05">
     <macros>
         <xml name="output" token_format="tabular" token_label="default description" token_name="default">
             <data format="@FORMAT@" label="@LABEL@ for ${on_string}" name="@NAME@">
@@ -15,6 +15,7 @@
     <expand macro="requirements"/>
     <expand macro="required_files"/>
     <command detect_errors="exit_code"><![CDATA[
+    export COMPlus_EnableDiagnostics=0 &&
     ## link galaxy datasets to filenames accepted by maxquant
     #import re
     #set names = [re.sub('@SUBSTITUTION_RX@', '_', str($n.element_identifier)) for $n in $input_opts.infiles]


### PR DESCRIPTION
In July, we missed the case in the file-type for `mzxml` for the `maxquant_mqpar` tool (we only fixed `maxquant`).  Consequently, the workflow editor won't allow connections to this input for `mzxml` files.