### PR TITLE
fix owner for deploy job

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -363,7 +363,7 @@ jobs:
   deploy:
     name: Deploy
     needs: [setup, lint, flake8, lintr, combine_outputs]
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproject' }}
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' ) && github.repository_owner == 'galaxyproteomics' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Hope this mistake only affected the openms run (https://github.com/galaxyproteomics/tools-galaxyp/actions/runs/3566803536)  .. which is unfortunate enough. 

I hope that restarting the workflow for OpenMS will use the new version after merging this one ... 