### PR TITLE
corrected sorting issue and non-useful parameter setting

### DIFF
--- a/tools/mqppep/macros.xml
+++ b/tools/mqppep/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.1.17</token>
+    <token name="@TOOL_VERSION@">0.1.18</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>

--- a/tools/mqppep/mqppep_anova_script.Rmd
+++ b/tools/mqppep/mqppep_anova_script.Rmd
@@ -81,7 +81,7 @@ params:
   # should correlation among substrates be used (rather than covariance)
   correlateSubstrates:  TRUE
   # only show covariance among variables having variance > 1
-  filterCovVarGT1:      TRUE
+  filterCovVarGT1:      FALSE
   # maximum number of residues to display for ppeps in rownames or columnames
   ppepTruncN:           10
   # maximum number of characters of subgenes to display in rownames or columnames
@@ -97,9 +97,6 @@ params:
   kinaseUprtDescLutBz2: "./kinase_uniprot_description_lut.tabular.bz2"
   # should debugging trace messages be printed?
   showEnrichedSubstrates: FALSE
-  # should debugging nb/nbe messages be printed?
-  printNBMsgs:          FALSE
-  #printNBMsgs:          TRUE
   # should row-scaling be applied to heatmaps: "none" or "row"
   defaultHeatMapRowScaling: !r c("none", "row")[1]
   # how missing values be displayed on heat maps: "NA" or " "
@@ -115,6 +112,9 @@ params:
   # when debugging files are needed, set debugFileBasePath to the path
   #   to the directory where they should be written
   debugFileBasePath:    !r if (TRUE) NULL else "test-data"
+  # should debugging nb/nbe messages be printed?
+  printNBMsgs:          FALSE
+  #printNBMsgs:          TRUE
 ---
 
 ```{r setup, include = FALSE, results = 'asis'}
@@ -6011,7 +6011,7 @@ if (have_kinase_descriptions) {
            p_value_data
          WHERE ppep = phosphopeptide
          GROUP BY kinase, ppep
-         ORDER BY kinase, ppep, p_value_data.quality DESC
+         ORDER BY kinase, p_value_data.quality DESC
       "),
       justification = "l l l l l l l",
       centered = TRUE,


### PR DESCRIPTION
Sort substrates by quality.
Do not filter out correlations less than one.