### PR TITLE
merged redundant parameters

### DIFF
--- a/tools/mqppep/MaxQuantProcessingScript.R
+++ b/tools/mqppep/MaxQuantProcessingScript.R
@@ -368,6 +368,8 @@ loc_prob_cutoff_graph_fn_svg <- args$locProbCutoffGraph_svg
 local_prob_cutoff <- args$localProbCutoff
 enriched <- args$enriched
 collapse_fn <- args$collapse_func
+if (collapse_fn == "average")
+  collapse_fn <- "mean"
 
 ### EXTRACT PARAMETERS from arguments end ------------------------------------
 

--- a/tools/mqppep/macros.xml
+++ b/tools/mqppep/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-    <token name="@TOOL_VERSION@">0.1.18</token>
+    <token name="@TOOL_VERSION@">0.1.19</token>
     <token name="@VERSION_SUFFIX@">0</token>
     <xml name="requirements">
         <requirements>
@@ -22,6 +22,10 @@
             <requirement type="package" version="1.7.3"   >r-optparse</requirement>
             <requirement type="package" version="1.4.4"   >r-reshape2</requirement>
             <requirement type="package" version="2.17"    >r-rmarkdown</requirement>
+            <!--
+            <requirement type="package" version="2.2.18"  >r-rsqlite</requirement>
+            <requirement type="package" version="0.4.2"   >r-sass</requirement>
+            -->
             <requirement type="package" version="1.2.2"   >r-sessioninfo</requirement>
             <requirement type="package" version="0.4_11"  >r-sqldf</requirement>
             <requirement type="package" version="1.4.1"   >r-stringr</requirement>

--- a/tools/mqppep/mqppep_preproc.xml
+++ b/tools/mqppep/mqppep_preproc.xml
@@ -35,7 +35,7 @@
         --startCol '$startcol_script'
         --intervalCol $intervalCol
         --localProbCutoff $localProbCutoff
-        --collapse_func $collapse_func
+        --collapse_func $merge_function
         -o '$phosphoPepIntensities'
         --locProbCutoffGraph $locProbCutoffGraph
         --enrichGraph $enrichGraph
@@ -121,22 +121,17 @@
             <option value="st" selected="true">pST</option>
             <option value="y">pY</option>
         </param>
-        <param name="collapse_func" type="select"
+        <param name="merge_function" type="select"
                label="Intensity merge function"
                help="When a peptide is multiply phosphorylated, how should intensities be merged? [default: sum]"
                >
             <option value="sum" selected="true">sum</option>
-            <option value="mean">average</option>
+            <option value="average">average</option>
         </param>
         <param name="localProbCutoff" type="float" value="0.75" min="0" max="1.0"
                label="Localization Probability Cutoff"
                help="See help below for an explanation."
                />
-        <param name="merge_function" type="select" label="intensity merge-function"
-               help="Specifies how intensities for identical phosphosites should be merged">
-            <option value="sum" selected="true">sum</option>
-            <option value="average">average</option>
-        </param>
         <param name="protein_fasta" type="data" format="fasta" label="UniProtKB/SwissProt FASTA database"
                help="Sequence database; supply the same FASTA file as you supplied to by MaxQuant"
                />
@@ -187,7 +182,6 @@
             <param name="phosphoCol" value="^Number of Phospho [(][STY][STY]*[)]$"/>
             <param name="startCol" value="^Intensity[^_]"/>
             <param name="intervalCol" value="1"/>
-            <param name="collapse_func" value="sum"/>
             <param name="localProbCutoff" value="0.75"/>
             <param name="species" value="human"/>
 
@@ -252,7 +246,6 @@
             <param name="phosphoCol" value="^Number of Phospho [(][STY][STY]*[)]$"/>
             <param name="startCol" value="^Intensity[^_]"/>
             <param name="intervalCol" value="1"/>
-            <param name="collapse_func" value="sum"/>
             <param name="localProbCutoff" value="0.75"/>
             <param name="species" value="human"/>
 
@@ -355,7 +348,7 @@ Localization probability cutoff
   Minimum localization probability; see above.
 
 Intensity merge-function
-  Specifies how intensities for identical phosphosites should be merged; see above.
+  Specifies how intensities for identical phosphosites should be merged. Choosing "sum" means that relative intensities reflect number of phospho-*residues*; choosing "average" means that relative intensities reflect number of phospho-*peptides*.
 
 Output datasets
 ===============


### PR DESCRIPTION
One parameter that applied to two stages of this tool was repeated for each stage, yet it should have the same value for both. This submission addresses this issue.