### PR TITLE
eggnog: allow admins to set --dbmem

### DIFF
--- a/tools/eggnog_mapper/eggnog_macros.xml
+++ b/tools/eggnog_mapper/eggnog_macros.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <macros>
    <token name="@TOOL_VERSION@">2.1.8</token>
-   <token name="@VERSION_SUFFIX@">3</token>
+   <token name="@VERSION_SUFFIX@">4</token>
    <token name="@EGGNOG_DB_VERSION@">5.0.2</token>
     <!--
     # DB versionning was super confusing for eggnog-mapper 2.0.x:

--- a/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
+++ b/tools/eggnog_mapper/eggnog_mapper/eggnog_mapper.xml
@@ -86,6 +86,7 @@
             #if $annotation_options.go_evidence:
                 --go_evidence=$annotation_options.go_evidence
             #end if
+            \$EGGNOG_DBMEM
         #end if
         $output_options.no_file_comments
         $output_options.report_orthologs


### PR DESCRIPTION
having the annotation DB on slow memory causes eggnog to be very inefficient in the annotation phase. For larger sequence databases to be processed we need to use more than 1 CPU .. and then the annotation phase is even more inefficient.

I hope that --dbmem can help here.