### PR TITLE
Increase default JVM stack size for PepQuery2

### DIFF
--- a/tools/pepquery2/macros.xml
+++ b/tools/pepquery2/macros.xml
@@ -1,6 +1,6 @@
  <macros>
     <token name="@TOOL_VERSION@">2.0.2</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1101/gr.235028.118</citation>

--- a/tools/pepquery2/pepquery2.xml
+++ b/tools/pepquery2/pepquery2.xml
@@ -33,6 +33,9 @@
 ## PepQuery command
 pepquery 
   -Xmx\$[ \${GALAXY_MEMORY_MB:-8192} / 1024 ]g
+#if $digestion.enzyme == '0'
+  -XX:ThreadStackSize=2048
+#end if
 #if $validation.task_type == "known"
   -s 2 $validation.decoy
 #else

--- a/tools/pepquery2/pepquery2.xml
+++ b/tools/pepquery2/pepquery2.xml
@@ -740,7 +740,7 @@ pepquery
             <output name="psm_rank_txt">
                 <assert_contents>
                     <has_text text="ELGSSDLTAR" />
-                    <has_line_matching expression="ELGSSDLTAR\tiTRAQ 4-plex of peptide N-term@0\[144.1\d+\]\t2\tiTRAQ_f4:3:2\t2\t1191.62\d+\t-3.04\d+\t-0.003\d+\t0.0\t1191.6\d+\t596.8\d+\t24.1\d+\t0\t0\t1\t995\t0.002\d+\t1\t0\tYes\t24.1\d+\t24.1\d+"/>
+                    <has_line_matching expression="ELGSSDLTAR\tiTRAQ 4-plex of peptide N-term@0\[144.1\d+\]\t2\tiTRAQ_f4:3:2\t2\t1191.62\d+\t-3.04\d+\t-0.003\d+\t0.0\t1191.6\d+\t596.8\d+\t24.1\d+\t0\t13\t1\t995\t0.002\d+\t1\t0\tYes\t10.3\d+\t8.23\d+"/>
                     <has_n_columns n="22" />
                 </assert_contents>
             </output>

--- a/tools/pepquery2/pepquery2.xml
+++ b/tools/pepquery2/pepquery2.xml
@@ -680,6 +680,72 @@ pepquery
             </output>
         </test>
 
+        <!-- Test-5  Non-enzyme search -->
+        <test expect_num_outputs="2">
+            <conditional name="validation">
+                <param name="task_type" value="novel"/>
+            </conditional>
+            <section name="req_inputs">
+                <conditional name="input_type">
+                    <param name="input_type_selector" value="peptide"/>
+                    <conditional name="multiple">
+                        <param name="peptide_input_selector" value="single" />
+                        <param name="input" value="ELGSSDLTAR"/>
+                    </conditional>
+                </conditional>
+                <conditional name="db_type">
+                    <param name="db_type_selector" value="history" />
+                    <param name="db_file" ftype="fasta" value="Uniprot.fasta"/>
+                </conditional>
+                <conditional name="ms_dataset">
+                    <param name="ms_dataset_type" value="history"/>
+                    <param name="spectrum_files" ftype="mgf" value="iTRAQ_f4.mgf"/>
+                </conditional>
+                <param name="indexType" value="1"/>
+            </section>
+            <param name="parameter_set" value=""/>
+            <section name="modifications">
+                 <!-- 21: iTRAQ 4-plex of K [144.1020624208] -->
+                 <!-- 22: iTRAQ 4-plex of peptide N-term [144.1020624208] -->
+                 <param name="fixed_mod" value="1,21,22"/>
+                 <!-- 2: Oxidation of M [15.99491461956] -->
+                 <param name="var_mod" value="2"/>
+                 <param name="max_mods" value="3"/>
+                 <param name="unmodified" value="True"/>
+                 <param name="aa" value="False"/>
+            </section>
+            <section name="digestion">
+                <param name="enzyme" value="0"/>
+            </section>
+            <section name="ms_params">
+                <section name="tolerance_params">
+                    <param name="precursor_tolerance" value="10"/>
+                    <param name="precursor_unit" value="ppm"/>
+                    <param name="tolerance" value="0.6"/>
+                </section>
+                <section name="search">
+                    <param name="frag_method" value="1"/>
+                    <param name="scoring_method" value="1"/>
+                    <param name="extra_score_validation" value="False"/>
+                    <param name="min_charge" value="2"/>
+                    <param name="max_charge" value="3"/>
+                    <param name="min_peaks" value="10"/>
+                    <param name="isotope_error" value="0"/>
+                    <param name="min_score" value="12"/>
+                    <param name="min_length" value="7"/>
+                    <param name="max_length" value="45"/>
+                    <param name="num_random_peptides" value="1000"/>
+                </section>
+            </section>
+            <output name="psm_rank_txt">
+                <assert_contents>
+                    <has_text text="ELGSSDLTAR" />
+                    <has_line_matching expression="ELGSSDLTAR\tiTRAQ 4-plex of peptide N-term@0\[144.1\d+\]\t2\tiTRAQ_f4:3:2\t2\t1191.62\d+\t-3.04\d+\t-0.003\d+\t0.0\t1191.6\d+\t596.8\d+\t24.1\d+\t0\t0\t1\t995\t0.002\d+\t1\t0\tYes\t24.1\d+\t24.1\d+"/>
+                    <has_n_columns n="22" />
+                </assert_contents>
+            </output>
+        </test>
+
     </tests>
     <help><![CDATA[
 **PepQuery2**

--- a/tools/pepquery2/pepquery2_index.xml
+++ b/tools/pepquery2/pepquery2_index.xml
@@ -12,7 +12,7 @@
 $index_spectrum_files($output.files_path, $inputs)
     ]]></command>
     <inputs>
-        <param name="inputs" argument="-i" type="data" format="mfg,mzml,mzxml" multiple="true" label="MS Spectrum files">
+        <param name="inputs" argument="-i" type="data" format="mgf,mzml,mzxml" multiple="true" label="MS Spectrum files">
         </param>
     </inputs>
     <outputs>


### PR DESCRIPTION
The "non enzyme" digestion option results in a much larger search space and deeper recursion within PepQuery2, which can result in a stack overflow. This PR sets the JVM per-thread stack size to 2048KB. The default on Linux x86_64 is 1024KB.

A small typo in the format attribute for input files is corrected as well.

