### PR TITLE
Fix DIA-NN

### DIFF
--- a/tools/diann/diann.xml
+++ b/tools/diann/diann.xml
@@ -468,6 +468,25 @@
                 </assert_contents>
             </output>
         </test>
+        <!-- test for library -->
+        <test expect_num_outputs="1">
+            <section name="input">
+                <param name="f" value="small-peakpicking-cwt-allMS.mzML" />
+                <section name="spectral_lib_options">
+                    <param name="gen_spec_lib" value="True"/>
+                    <param name="lib" value="report-lib.tsv.speclib"/>
+                </section>
+                <section name="fasta_db_options">
+                    <param name="fasta" value="bsa.fasta,bsa2.fasta"/>
+                    <param name="fasta_search" value="True"/>
+                </section>
+            </section>
+            <output name="output_report" file="report.tsv">
+                <assert_contents>
+                    <has_text text="PG.Normalised"/>
+                </assert_contents>
+            </output>
+        </test>
         <!-- test for Bruker data -->
 <!--        <test expect_num_outputs="2">-->
 <!--            <section name="input">-->

--- a/tools/diann/diann.xml
+++ b/tools/diann/diann.xml
@@ -468,7 +468,7 @@
                 </assert_contents>
             </output>
         </test>
-        <!-- test for library -->
+        <!-- test for spec library -->
         <test expect_num_outputs="1">
             <section name="input">
                 <param name="f" value="small-peakpicking-cwt-allMS.mzML" />

--- a/tools/diann/diann.xml
+++ b/tools/diann/diann.xml
@@ -469,7 +469,7 @@
             </output>
         </test>
         <!-- test for library -->
-        <test expect_num_outputs="1">
+        <test expect_num_outputs="4">
             <section name="input">
                 <param name="f" value="small-peakpicking-cwt-allMS.mzML" />
                 <section name="spectral_lib_options">
@@ -486,6 +486,13 @@
                     <has_text text="PG.Normalised"/>
                 </assert_contents>
             </output>
+            <output name="output_report_lib" file="report-lib.tsv">
+                <assert_contents>
+                    <has_text text="PrecursorMz"/>
+                </assert_contents>
+            </output>
+            <output name="output_report_speclib" file="report-lib.tsv.speclib" compare="sim_size" delta="100"/>
+            <output name="output_report_pred_speclib" file="report-lib.predicted.speclib" compare="sim_size" delta="100"/>
         </test>
         <!-- test for Bruker data -->
 <!--        <test expect_num_outputs="2">-->

--- a/tools/diann/diann.xml
+++ b/tools/diann/diann.xml
@@ -2,7 +2,7 @@
     <description>is a software for DIA/SWATH data processing</description>
     <macros>
         <token name="@TOOL_VERSION@">1.8.1</token>
-        <token name="@VERSION_SUFFIX@">1</token>
+        <token name="@VERSION_SUFFIX@">2</token>
     </macros>
     <requirements>
         <container type="docker">biocontainers/diann:v@TOOL_VERSION@_cv1</container>
@@ -29,13 +29,17 @@
             #set $fasta_file_str += '--fasta ' + str($fasta_file) + ' '
         #end for
 
+        #if $input.spectral_lib_options.lib
+            ln -s '$input.spectral_lib_options.lib' './input_data/report-lib.predicted.speclib' &&
+        #end if
+
         diann
             #if $input.f != 'None'
             '$infiles_str'
             #end if
             --dir ./
             #if $input.spectral_lib_options.lib
-            --lib '$input.spectral_lib_options.lib'
+            --lib './input_data/report-lib.predicted.speclib'
             #else
             --lib
             #end if

--- a/tools/diann/diann.xml
+++ b/tools/diann/diann.xml
@@ -469,11 +469,10 @@
             </output>
         </test>
         <!-- test for library -->
-        <test expect_num_outputs="4">
+        <test expect_num_outputs="1">
             <section name="input">
                 <param name="f" value="small-peakpicking-cwt-allMS.mzML" />
                 <section name="spectral_lib_options">
-                    <param name="gen_spec_lib" value="True"/>
                     <param name="lib" value="report-lib.predicted.speclib"/>
                 </section>
                 <section name="fasta_db_options">
@@ -486,13 +485,6 @@
                     <has_text text="PG.Normalised"/>
                 </assert_contents>
             </output>
-            <output name="output_report_lib" file="report-lib.tsv">
-                <assert_contents>
-                    <has_text text="PrecursorMz"/>
-                </assert_contents>
-            </output>
-            <output name="output_report_speclib" file="report-lib.tsv.speclib" compare="sim_size" delta="100"/>
-            <output name="output_report_pred_speclib" file="report-lib.predicted.speclib" compare="sim_size" delta="100"/>
         </test>
         <!-- test for Bruker data -->
 <!--        <test expect_num_outputs="2">-->

--- a/tools/diann/diann.xml
+++ b/tools/diann/diann.xml
@@ -474,7 +474,7 @@
                 <param name="f" value="small-peakpicking-cwt-allMS.mzML" />
                 <section name="spectral_lib_options">
                     <param name="gen_spec_lib" value="True"/>
-                    <param name="lib" value="report-lib.tsv.speclib"/>
+                    <param name="lib" value="report-lib.predicted.speclib"/>
                 </section>
                 <section name="fasta_db_options">
                     <param name="fasta" value="bsa.fasta,bsa2.fasta"/>


### PR DESCRIPTION
There is a problem when the user wants to use a custom library. DIA-NN does not ~~find~~recognize the speclib file if it is in the temp folder (with a .dat extension). Added a test to cover this issue.