### PR TITLE
Add bio.tools for FlashLFQ

### DIFF
--- a/tools/flashlfq/flashlfq.xml
+++ b/tools/flashlfq/flashlfq.xml
@@ -1,5 +1,8 @@
 <tool id="flashlfq" name="FlashLFQ" version="1.0.3.1">
     <description>ultrafast label-free quantification for mass-spectrometry proteomics</description>
+    <xrefs>
+        <xref type="bio.tools">flashlfq</xref>
+    </xrefs>
     <requirements>
         <requirement type="package" version="1.0.3">flashlfq</requirement>
     </requirements>


### PR DESCRIPTION
Hi all,

This PR links the tools to its bio.tools entry: https://bio.tools/flashlfq
It will be useful to get EDAM ontology annotations

Bérénice
