### PR TITLE
Fix boolean to select bugs in msconvert

### DIFF
--- a/tools/msconvert/msconvert.xml
+++ b/tools/msconvert/msconvert.xml
@@ -1,4 +1,4 @@
-<tool id="msconvert" name="msconvert" version="@VERSION@.3">
+<tool id="msconvert" name="msconvert" version="@VERSION@.4">
     <description>Convert and/or filter mass spectrometry files</description>
     <macros>
         <import>msconvert_macros.xml</import>

--- a/tools/msconvert/msconvert_macros.xml
+++ b/tools/msconvert/msconvert_macros.xml
@@ -32,7 +32,7 @@
       #set inputmask = "'"+$basename+"'"
     #end if
 
-    #if $data_processing.precursor_refinement.use_mzrefinement
+    #if $data_processing.precursor_refinement.use_mzrefinement == "true"
       #set input_ident_name = ".".join((os.path.splitext($basename)[0], $data_processing.precursor_refinement.input_ident.ext))
       #set output_refinement_name = os.path.splitext($basename)[0] + '.mzRefinement.tsv'
       ln -s '$data_processing.precursor_refinement.input_ident' '$input_ident_name' &&
@@ -65,7 +65,7 @@
       --filter "scanSumming precursorTol=$general_options.scan_summing.precursorTol scanTimeTol=$general_options.scan_summing.scanTimeTol ionMobilityTol=$general_options.scan_summing.ionMobilityTol"
     #end if
 
-    #if $general_options.multi_run_output.do_multi_run_output:
+    #if $general_options.multi_run_output.do_multi_run_output == "true":
       #if len($general_options.multi_run_output.run_index_set) > 0
         --runIndexSet "
         #for $index in $general_options.multi_run_output.run_index_set
@@ -85,7 +85,7 @@
         --filter "peakPicking $data_processing.peak_picking.pick_peaks_algorithm msLevel=$data_processing.peak_picking.pick_peaks_ms_levels"
       #end if
 
-      #if $data_processing.precursor_refinement.use_mzrefinement
+      #if $data_processing.precursor_refinement.use_mzrefinement == "true"
       --filter "mzRefiner $input_ident_name
         msLevels=$data_processing.precursor_refinement.precursor_refinement_ms_levels
         thresholdScore=$data_processing.precursor_refinement.thresholdScore
@@ -229,7 +229,7 @@
         #end if
       #end if
 
-      #if $data_processing.precursor_refinement.use_mzrefinement
+      #if $data_processing.precursor_refinement.use_mzrefinement == "true"
         && mv '$output_refinement_name' '$output_refinement';
       #end if
 ]]>
@@ -560,10 +560,10 @@
         </change_format>
       </data>
       <data format="tsv" name="output_refinement" label="${($input.name[:-4] if $input.name.endswith('.tar') else $input.name).rsplit('.',1)[0]}.mzRefinement.tsv">
-        <filter>data_processing['precursor_refinement']['use_mzrefinement'] == True</filter>
+        <filter>data_processing['precursor_refinement']['use_mzrefinement'] == "true"</filter>
       </data>
       <collection name="multi_run_output_list" type="list" label="${($input.name[:-4] if $input.name.endswith('.tar') else $input.name).rsplit('.',1)[0]}.${output_type} collection">
-        <filter>general_options['multi_run_output']['do_multi_run_output'] == True</filter>
+        <filter>general_options['multi_run_output']['do_multi_run_output'] == "true"</filter>
         <discover_datasets pattern="__name_and_ext__" directory="outputs" />
       </collection>
     </outputs>


### PR DESCRIPTION
Fixes
```
NotFound: cannot find 'input_ident' while searching for 'data_processing.precursor_refinement.input_ident.ext'
  File "galaxy/jobs/runners/__init__.py", line 297, in prepare_job
    job_wrapper.prepare()
  File "galaxy/jobs/__init__.py", line 1256, in prepare
    ) = tool_evaluator.build()
  File "galaxy/tools/evaluation.py", line 588, in build
    global_tool_logs(self._build_command_line, config_file, "Building Command Line")
  File "galaxy/tools/evaluation.py", line 98, in global_tool_logs
    raise e
  File "galaxy/tools/evaluation.py", line 94, in global_tool_logs
    return func()
  File "galaxy/tools/evaluation.py", line 611, in _build_command_line
    command_line = fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 115, in fill_template
    return fill_template(
  File "galaxy/util/template.py", line 123, in fill_template
    raise first_exception or e
  File "galaxy/util/template.py", line 87, in fill_template
    return unicodify(t, log_exception=False)
  File "galaxy/util/__init__.py", line 1196, in unicodify
    value = str(value)
  File "Cheetah/Template.py", line 1053, in __unicode__
    return getattr(self, mainMethName)()
  File "cheetah_DynamicallyCompiledCheetahTemplate_1712898486_6070771_49370.py", line 146, in respond
```

which broke in https://github.com/galaxyproteomics/tools-galaxyp/pull/748/commits/79947db04a2b8dc6db2465f71a9554a320cb5255.

@bebatut is there a chance that you could go over your recent EDAM related commits and see if this has happened elsewhere ?