### PR TITLE
Remove raw file option from PepQuery2

### DIFF
--- a/tools/pepquery2/macros.xml
+++ b/tools/pepquery2/macros.xml
@@ -1,6 +1,6 @@
  <macros>
     <token name="@TOOL_VERSION@">2.0.2</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1101/gr.235028.118</citation>
@@ -20,7 +20,7 @@
     #end if
 #end def
 #def clean($name1)
-    #set $name_clean = $re.sub('[^\w\-_]', '_', $re.sub('(?i)[.](fa|fas|fasta|imzml|mzml|mzxml|mgf|raw)$','', $re.sub('.*/','', $name1.rstrip('.gz'))))
+    #set $name_clean = $re.sub('[^\w\-_]', '_', $re.sub('(?i)[.](fa|fas|fasta|imzml|mzml|mzxml|mgf)$','', $re.sub('.*/','', $name1.rstrip('.gz'))))
     #return $name_clean
 #end def
 #def ln_name($ds)
@@ -31,8 +31,6 @@
         #set $ext = ".mzXML"
     #else if $ds.is_of_type('mgf')
         #set $ext = ".mgf"
-    #else if $ds.is_of_type('thermo.raw')
-        #set $ext = ".raw"
     #else if $ds.is_of_type('fasta')
         #set $ext = ".fasta"
     #end if

--- a/tools/pepquery2/pepquery2.xml
+++ b/tools/pepquery2/pepquery2.xml
@@ -159,7 +159,7 @@ pepquery
             </param>
             <when value="novel"/> 
             <when value="known"> 
-                 <param name="decoy" argument="-decoy" type="boolean" truevalue="-decoy" falsevalue="" checked="false" label="Identity the decoy version of the selected target protein"/>
+                 <param argument="-decoy" type="boolean" truevalue="-decoy" falsevalue="" checked="false" label="Identity the decoy version of the selected target protein"/>
             </when>
         </conditional>
         <section name="req_inputs" title="Input Data" expanded="true">
@@ -276,7 +276,7 @@ pepquery
                 </when>
             </conditional>
 
-            <param name="indexType" argument="-indexType" type="select" optional="true" label="Report Spectrum Scan as" help="Default: index" >
+            <param argument="-indexType" type="select" optional="true" label="Report Spectrum Scan as" help="Default: index" >
                 <option value="1">index (1-based) in MGF</option>
                 <option value="2">spectrum title in MGF</option>
             </param>
@@ -307,7 +307,7 @@ pepquery
 
              <param name="max_mods" argument="-maxVar" type="integer" label="Max Modifications" value="" min="0" max="10" optional="true" help="Max number of variable modifications  Default: 3" />
              <param name="unmodified" argument="-hc" type="boolean" truevalue="-hc" falsevalue="" checked="false" label="Use more stringent criterion for unrestricted modification searching" help="TRUE: score(UMS)>=score(targetPSM); FALSE: score(UMS)>score(targetPSM)" />
-             <param name="aa" argument="-aa" type="boolean" truevalue="-aa" falsevalue="" checked="false" label="Consider amino acid substitution modifications?" help="Whether or not to consider aa substitution modifications when perform modification filtering." />
+             <param argument="-aa" type="boolean" truevalue="-aa" falsevalue="" checked="false" label="Consider amino acid substitution modifications?" help="Whether or not to consider aa substitution modifications when perform modification filtering." />
         </section>
 
         <section name="digestion" title="Digestion" expanded="false">
@@ -369,7 +369,7 @@ pepquery
             <option value="ptm_detail.txt">ptm_detail.txt</option>
             <option value="ms_index">MS/MS Index</option>
         </param>
-        <param name="fast" argument="-fast" type="boolean" truevalue="-fast" falsevalue="" checked="false" label="Use fast mode for searching" help="In fast mode, only one better match from reference peptide-based competitive filtering steps will be returned. A peptide identified or not is not affected by this setting. For most applications, fast mode will speed up the analysis." />
+        <param argument="-fast" type="boolean" truevalue="-fast" falsevalue="" checked="false" label="Use fast mode for searching" help="In fast mode, only one better match from reference peptide-based competitive filtering steps will be returned. A peptide identified or not is not affected by this setting. For most applications, fast mode will speed up the analysis." />
     </inputs>
     <outputs>
         <data name="log_txt" format="txt" from_work_dir="log.txt" label="${tool.name} on ${on_string}: log.txt">

--- a/tools/pepquery2/pepquery2.xml
+++ b/tools/pepquery2/pepquery2.xml
@@ -257,7 +257,7 @@ pepquery
                     <option value="public">public proteomics data repositories</option>
                 </param>
                 <when value="history">
-                    <param name="spectrum_files" argument="-ms" type="data" format="mgf,mzml,mzxml,thermo.raw" label="Spectrum File" help="Spectrum file used for identification, formats: MGF,mzML,mzXML,Thermo RAW" />
+                    <param name="spectrum_files" argument="-ms" type="data" format="mgf,mzml,mzxml" label="Spectrum File" help="Spectrum file used for identification, formats: MGF,mzML,mzXML" />
                 </when>
                 <when value="indexed">
                     <param name="index" argument="-ms" type="data" format="txt" label="PepQuery Index" help="" />

--- a/tools/pepquery2/pepquery2_show_sets.xml
+++ b/tools/pepquery2/pepquery2_show_sets.xml
@@ -45,7 +45,7 @@ echo "PepQuery2 Show Sets $sets"
         </data>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="1">
             <output name="pepquerydb">
                 <assert_contents>
                     <has_text text="CPTAC_PDA_Discovery_Study_Proteome_PDC000270" />


### PR DESCRIPTION
Raw input files do not work with the current PepQuery galaxy implementation. The `-dc` flag must be used to pass a ThermoRawFileParser executable to pepquery, which will require further modifications to the pepquery recipe.

For the time being, remove this option.