### PR TITLE
add enzyme list to morpheus tool

### DIFF
--- a/tools/morpheus/.shed.yml
+++ b/tools/morpheus/.shed.yml
@@ -3,6 +3,7 @@ name: morpheus
 categories:
 - Proteomics
 description: Morpheus MS Search Application
+homepage_url: https://cwenger.github.io/Morpheus
 long_description: |
   Morpheus database search algorithm for high-resolution tandem mass spectra.   
 

--- a/tools/morpheus/macros.xml
+++ b/tools/morpheus/macros.xml
@@ -1,5 +1,5 @@
 <macros>
-        <token name="@TOOL_VERSION@">2.255.0</token>
+        <token name="@TOOL_VERSION@">288</token>
         <token name="@VERSION_SUFFIX@">0</token>
 	<token name="@PROFILE@">22.05</token>
 	<xml name="edam_ontology">
@@ -18,7 +18,7 @@
     	</xml>
 	<xml name="requirements">
            <requirements>
-             <requirement type="package" version="255">morpheus</requirement>
+             <requirement type="package" version="@TOOL_VERSION@">morpheus</requirement>
     	   </requirements>
 	</xml>
         <xml name="modification_options">

--- a/tools/morpheus/macros.xml
+++ b/tools/morpheus/macros.xml
@@ -1,0 +1,77 @@
+<macros>
+        <token name="@TOOL_VERSION@">2.255.0</token>
+        <token name="@VERSION_SUFFIX@">0</token>
+	<token name="@PROFILE@">22.05</token>
+	<xml name="edam_ontology">
+	  <edam_topics>
+	     <edam_topic>topic_0121</edam_topic>
+     	  </edam_topics>
+          <edam_operations>
+	     <edam_operation>operation_2479</edam_operation>
+	     <edam_operation>operation_3092</edam_operation>
+          </edam_operations>
+  	</xml>
+        <xml name="biotools">
+            <xrefs>
+               <xref type="bio.tools">morpheus</xref>
+            </xrefs>
+    	</xml>
+	<xml name="requirements">
+           <requirements>
+             <requirement type="package" version="255">morpheus</requirement>
+    	   </requirements>
+	</xml>
+        <xml name="modification_options">
+            <option value="acetylation of protein N-terminus">acetylation of protein N-terminus</option>
+            <option value="acetylation of lysine">acetylation of lysine</option>
+            <option value="phosphorylation of S">phosphorylation of S</option>
+            <option value="phosphorylation of T">phosphorylation of T</option>
+            <option value="phosphorylation of Y">phosphorylation of Y</option>
+            <option value="deamidation of N">deamidation of N</option>
+            <option value="deamidation of Q">deamidation of Q</option>
+            <option value="pyro-cmC">pyro-cmC</option>
+            <option value="pyro-E">pyro-E</option>
+            <option value="pyro-Q">pyro-Q</option>
+            <option value="TMT zero on peptide N-terminus">TMT zero on peptide N-terminus</option>
+            <option value="TMT zero on K">TMT zero on K</option>
+            <option value="TMT zero on Y">TMT zero on Y</option>
+            <option value="TMT duplex on peptide N-terminus">TMT duplex on peptide N-terminus</option>
+            <option value="TMT duplex on K">TMT duplex on K</option>
+            <option value="TMT duplex on Y">TMT duplex on Y</option>
+            <option value="TMT sixplex/tenplex on peptide N-terminus">TMT sixplex/tenplex on peptide N-terminus</option>
+            <option value="TMT sixplex/tenplex on K">TMT sixplex/tenplex on K</option>
+            <option value="TMT sixplex/tenplex on Y">TMT sixplex/tenplex on Y</option>
+            <option value="iTRAQ 4-plex on peptide N-terminus">iTRAQ 4-plex on peptide N-terminus</option>
+            <option value="iTRAQ 4-plex on K">iTRAQ 4-plex on K</option>
+            <option value="iTRAQ 4-plex on Y">iTRAQ 4-plex on Y</option>
+            <option value="iTRAQ 8-plex on peptide N-terminus">iTRAQ 8-plex on peptide N-terminus</option>
+            <option value="iTRAQ 8-plex on K">iTRAQ 8-plex on K</option>
+            <option value="iTRAQ 8-plex on Y    ">iTRAQ 8-plex on Y    </option>
+        </xml>
+        <xml name="variable_modification_options">
+            <option value="oxidation of M" selected="true">oxidation of M</option>
+            <option value="carbamidomethylation of C">carbamidomethylation of C</option>
+            <expand macro="modification_options"/>
+        </xml>
+        <xml name="fixed_modification_options">
+            <option value="carbamidomethylation of C" selected="true">carbamidomethylation of C</option>
+            <option value="oxidation of M">oxidation of M</option>
+            <expand macro="modification_options"/>
+    	</xml>
+	<xml name="proteases_options">
+	    <option value="Arg-C">Arg-C</option>
+	    <option value="Asp-N" >Asp-N</option>
+	    <option value="chymotrypsin (no proline rule)" >chymotrypsin (no proline rule)</option>
+	    <option value="Glu-C" >Glu-C</option>
+	    <option value="Lys-C" >Lys-C</option>
+	    <option value="Lys-C (no proline rule)" >Lys-C (no proline rule)</option>
+	    <option value="Lys-N" >Lys-N</option>
+	    <option value="semi-trypsin" >semi-trypsin</option>
+	    <option value="semi-trypsin (no proline rule)" >semi-trypsin (no proline rule)</option>
+	    <option value="trypsin" >trypsin</option>
+	    <option value="trypsin (no proline rule)" selected="true">trypsin (no proline rule)</option>
+	    <option value="tryptophan oxidation" >tryptophan oxidation</option>
+	    <option value="non-specific" >non-specific</option>
+	    <option value="top-down" >top-down</option>
+	</xml>
+</macros>

--- a/tools/morpheus/morpheus.xml
+++ b/tools/morpheus/morpheus.xml
@@ -1,49 +1,11 @@
-<tool id="morpheus" name="Morpheus" version="2.255.0">
+<tool id="morpheusid" name="Morpheus" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>database search algorithm for high-resolution tandem mass spectra</description>
     <macros>
-        <xml name="modification_options">
-            <option value="acetylation of protein N-terminus">acetylation of protein N-terminus</option>
-            <option value="acetylation of lysine">acetylation of lysine</option>
-            <option value="phosphorylation of S">phosphorylation of S</option>
-            <option value="phosphorylation of T">phosphorylation of T</option>
-            <option value="phosphorylation of Y">phosphorylation of Y</option>
-            <option value="deamidation of N">deamidation of N</option>
-            <option value="deamidation of Q">deamidation of Q</option>
-            <option value="pyro-cmC">pyro-cmC</option>
-            <option value="pyro-E">pyro-E</option>
-            <option value="pyro-Q">pyro-Q</option>
-            <option value="TMT zero on peptide N-terminus">TMT zero on peptide N-terminus</option>
-            <option value="TMT zero on K">TMT zero on K</option>
-            <option value="TMT zero on Y">TMT zero on Y</option>
-            <option value="TMT duplex on peptide N-terminus">TMT duplex on peptide N-terminus</option>
-            <option value="TMT duplex on K">TMT duplex on K</option>
-            <option value="TMT duplex on Y">TMT duplex on Y</option>
-            <option value="TMT sixplex/tenplex on peptide N-terminus">TMT sixplex/tenplex on peptide N-terminus</option>
-            <option value="TMT sixplex/tenplex on K">TMT sixplex/tenplex on K</option>
-            <option value="TMT sixplex/tenplex on Y">TMT sixplex/tenplex on Y</option>
-            <option value="iTRAQ 4-plex on peptide N-terminus">iTRAQ 4-plex on peptide N-terminus</option>
-            <option value="iTRAQ 4-plex on K">iTRAQ 4-plex on K</option>
-            <option value="iTRAQ 4-plex on Y">iTRAQ 4-plex on Y</option>
-            <option value="iTRAQ 8-plex on peptide N-terminus">iTRAQ 8-plex on peptide N-terminus</option>
-            <option value="iTRAQ 8-plex on K">iTRAQ 8-plex on K</option>
-            <option value="iTRAQ 8-plex on Y    ">iTRAQ 8-plex on Y    </option>
-        </xml>
-        <xml name="variable_modification_options">
-            <option value="oxidation of M" selected="true">oxidation of M</option>
-            <option value="carbamidomethylation of C">carbamidomethylation of C</option>
-            <expand macro="modification_options"/>
-        </xml>
-        <xml name="fixed_modification_options">
-            <option value="carbamidomethylation of C" selected="true">carbamidomethylation of C</option>
-            <option value="oxidation of M">oxidation of M</option>
-            <expand macro="modification_options"/>
-        </xml>
+	  <import>macros.xml</import>
     </macros>
-
-    <requirements>
-        <requirement type="package" version="255">morpheus</requirement>
-    </requirements>
-
+    <expand macro="edam_ontology"/>
+    <expand macro="biotools"/>
+    <expand macro="requirements"/>
     <stdio>
         <exit_code range="1:" />
         <regex match="System..*Exception"
@@ -150,7 +112,10 @@
         #if str($vm) != 'None':
             #set $vmods = str($vm).replace(',',';')
             -vm="$vmods"
-        #end if
+	#end if
+	#if str($p) != 'None':
+	   -p="$p"
+	#end if
         -mt=\${GALAXY_SLOTS:-4}
         #set $out_list = 'log.txt summary.tsv aggregate.PSMs.tsv aggregate.unique_peptides.tsv aggregate.protein_groups.tsv aggregate.mzid *.pep.xml'
         #if len($input_list) == 1:
@@ -171,7 +136,10 @@
         </param>
         <param name="vm" type="select" multiple="true" optional="true" label="Variable Modifications">
             <expand macro="variable_modification_options" />
-        </param>
+    	</param>
+	<param name="p" type="select" label="Proteases">
+	    <expand macro="proteases_options"/>
+	</param>
         <param name="fdr" type="float" value="1" optional="true" min="0.0" max="100.0" label="FDR (Maximum False Discovery Rate percent)" />
         <param name="mvmi" type="integer" value="1024" optional="true" min="0" label="Maximum Variable Modification Isoforms Per Peptide" />
         <param name="precmtv" type="float" value="10." optional="true" label="Precursor Mass Tolerance Value" />
@@ -270,6 +238,24 @@
                     <not_has_text text="K.TTGSSSSSSSK.K" />
                 </assert_contents>
             </output>
+    	</test>
+        <test>
+            <param name="inputs" value="test_input.mzML" ftype="mzml"/>
+            <param name="searchdb" value="uniprot-proteome_UP000002311-first100entries.fasta" ftype="fasta"/>
+            <param name="fdr" value="1"/>
+            <param name="mvmi" value="1024"/>
+            <param name="precmt" value="Monoisotopic"/>
+            <param name="precmtu" value="Da"/>
+            <param name="precmtv" value="2.5"/>
+            <param name="fm" value="carbamidomethylation of C"/>
+	    <param name="vm" value="oxidation of M"/>
+	    <param name="p" value="trypsin" />
+            <output name="output_psms">
+                <assert_contents>
+                    <has_text text="K.DGM(oxidation of M)KAYAQNVQQR.E" />
+                    <not_has_text text="K.TTGSSSSSSSK.K" />
+                </assert_contents>
+            </output>
         </test>
         <test>
             <param name="inputs" value="test_input.mzML" ftype="mzml"/>
@@ -307,7 +293,26 @@
                 </assert_contents>
             </output>
         </test>
-
+        <test>
+            <param name="inputs" value="test_input.mzML" ftype="mzml"/>
+            <param name="searchdb" value="uniprot-proteome_UP000002311Condensed-first100entries.xml" ftype="uniprotxml"/>
+            <param name="fdr" value="1"/>
+            <param name="mvmi" value="1024"/>
+            <param name="precmt" value="Monoisotopic"/>
+            <param name="precmtu" value="Da"/>
+            <param name="precmtv" value="2.5"/>
+            <param name="fm" value="carbamidomethylation of C"/>
+	    <param name="vm" value="oxidation of M"/>
+	    <param name="p" value="trypsin"/>
+            <param name="adv_options_selector" value="set"/>
+            <param name="prodmtv" value=".01"/>
+            <output name="output_psms">
+                <assert_contents>
+                    <has_text text="R.KRSLFDS(UniProt: Phosphoserine)AFSSR.A" />
+                    <not_has_text text="K.KYFLENKIGTDR.R" />
+                </assert_contents>
+            </output>
+        </test>
     </tests>
     <help><![CDATA[
 Morpheus_ is a database search algorithm for high-resolution tandem mass spectra. 

--- a/tools/morpheus/morpheus.xml
+++ b/tools/morpheus/morpheus.xml
@@ -269,7 +269,7 @@
             <param name="vm" value="oxidation of M"/>
             <output name="output_psms">
                 <assert_contents>
-                    <has_text text="R.KRSLFDS(UniProt: Phosphoserine)AFSSR.A" />
+                    <has_text text="K.RSPSGNISTNSMR.P" />
                     <not_has_text text="K.KYFLENKIGTDR.R" />
                 </assert_contents>
             </output>
@@ -308,7 +308,7 @@
             <param name="prodmtv" value=".01"/>
             <output name="output_psms">
                 <assert_contents>
-                    <has_text text="R.KRSLFDS(UniProt: Phosphoserine)AFSSR.A" />
+                    <has_text text="K.KTLKSDGVAGLYR.G" />
                     <not_has_text text="K.KYFLENKIGTDR.R" />
                 </assert_contents>
             </output>

--- a/tools/morpheus/morpheus.xml
+++ b/tools/morpheus/morpheus.xml
@@ -1,4 +1,4 @@
-<tool id="morpheusid" name="Morpheus" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
+<tool id="morpheus" name="Morpheus" version="@TOOL_VERSION@+galaxy@VERSION_SUFFIX@" profile="@PROFILE@">
     <description>database search algorithm for high-resolution tandem mass spectra</description>
     <macros>
 	  <import>macros.xml</import>


### PR DESCRIPTION
FOR CONTRIBUTOR:

[x]I have read the [CONTRIBUTING.md](https://github.com/galaxyproject/tools-iuc/blob/master/CONTRIBUTING.md) document and this tool is appropriate for the tools-iuc repo.
[x]License permits unrestricted use (educational + commercial)
[x]This PR adds a new tool or tool collection
[x]This PR updates an existing tool or tool collection
[]This PR does something else (explain below)

Background:
The morpheus wrapper does not have the parameter (p) which allows user to select enzyme to be used in the morpheus search process. The option p is listed in https://cwenger.github.io/Morpheus/args.html . 

In addition to include the p option in the wrapper. I have tidied up the morpheus wrapper by creating a macro file for tool version , tokens, values and enzyme list for the paramters used in the wrapper. 