### PR TITLE
Lower-case mzml and mzxml input datatypes

### DIFF
--- a/tools/fragpipe/macros.xml
+++ b/tools/fragpipe/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <import>msfragger_macros.xml</import>
     <token name="@TOOL_VERSION@">20.0</token>
-    <token name="@VERSION_SUFFIX@">0</token>
+    <token name="@VERSION_SUFFIX@">1</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">fragpipe</requirement>
@@ -20,7 +20,7 @@
       name, experiment, bioreplicate, data type
     -->
     <xml name="samples">
-        <param name="inputs" type="data" format="mzML,mzXML" multiple="true" label="Proteomics Spectrum files"  help="All input scan files must of a matching format: mzML, mzXML"/>
+        <param name="inputs" type="data" format="mzml,mzxml" multiple="true" label="Proteomics Spectrum files"  help="All input scan files must of a matching format: mzML, mzXML"/>
         <param name="input_prefix" type="text" value="" optional="true" label="File name prefix" help="Names inputs: prefix_rep#.mzXML Leave blank to use History names of inputs">
               <validator type="regex" message="">[a-zA-Z][a-zA-Z0-9_-]*</validator>
         </param>


### PR DESCRIPTION
In recent changes I made these became partially uppercase.

The input datatype seems to be case-insensitive in the history / tests context, but we just caught this when building a workflow. The FragPipe step won't accept mzml inputs because these strings are not fully lowercase.