### PR TITLE
Add thermo.raw as an Accepted Datatype for Scan File.

### DIFF
--- a/tools/fragpipe/macros.xml
+++ b/tools/fragpipe/macros.xml
@@ -20,11 +20,11 @@
       name, experiment, bioreplicate, data type
     -->
     <xml name="samples">
-        <param name="inputs" type="data" format="mzml,mzxml" multiple="true" label="Proteomics Spectrum files"  help="All input scan files must of a matching format: mzML, mzXML"/>
+        <param name="inputs" type="data" format="mzml,mzxml,thermo.raw" multiple="true" label="Proteomics Spectrum files"  help="All input scan files must be named with one of the following extensions: .mzML, .mzXML, or .raw"/>
         <param name="input_prefix" type="text" value="" optional="true" label="File name prefix" help="Names inputs: prefix_rep#.mzXML Leave blank to use History names of inputs">
               <validator type="regex" message="">[a-zA-Z][a-zA-Z0-9_-]*</validator>
         </param>
-        <param name="manifest" type="data" format="tabular" label="Manifest file" help="TSV file with entries for each input scan file: Name (Name of input Galaxy history item. Extension in the name must be mzML or mzXML.), Experiment (empty, alphanumeric, or _), Bioreplicate (empty or integer), Data type (DDA, DIA, GPF-DIA, DIA-Quant, or DIA-lib)"/>
+        <param name="manifest" type="data" format="tabular" label="Manifest file" help="TSV file with entries for each input scan file: Name (Name of input Galaxy history item. Extension in the name must be .mzML, .mzXML, or .raw.), Experiment (empty, alphanumeric, or _), Bioreplicate (empty or integer), Data type (DDA, DIA, GPF-DIA, DIA-Quant, or DIA-lib)"/>
     </xml>
 
     <!--

--- a/tools/fragpipe/macros.xml
+++ b/tools/fragpipe/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <import>msfragger_macros.xml</import>
     <token name="@TOOL_VERSION@">20.0</token>
-    <token name="@VERSION_SUFFIX@">1</token>
+    <token name="@VERSION_SUFFIX@">2</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">fragpipe</requirement>


### PR DESCRIPTION
I removed this option when I overlooked that mono is already a dependency of the MSFragger recipe. The Galaxy tool can in-fact take `thermo.raw` files directly - we have run local jobs with this option already.