### PR TITLE
Adds option to run FragPipe job with higher memory

### DIFF
--- a/tools/fragpipe/fragpipe.xml
+++ b/tools/fragpipe/fragpipe.xml
@@ -71,6 +71,9 @@
         <!-- Only generate a workflow, don't run FragPipe -->
         <param name="workflow_only" type="boolean" truevalue="yes" falsevalue="no" checked="false" label="Only generate the workflow output"/>
 
+        <!-- Galaxy admins may utilize this variable to for jobs requiring higher memory  -->
+        <param name="high_memory" type="boolean" checked="false" label="High memory job" help="This option is made available for Galaxy administrators to allocate more resources to FragPipe when selected. It may not be used by all systems - please contact your adminstrator to learn if your Galaxy instance does."/>
+
         <param name="output_options" label="Additional outputs" type="select" multiple="true" display="checkboxes" optional="true">
             <option value="workflow">FragPipe Workflow</option>
             <option value="log">FragPipe Log</option>

--- a/tools/fragpipe/macros.xml
+++ b/tools/fragpipe/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <import>msfragger_macros.xml</import>
     <token name="@TOOL_VERSION@">20.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">fragpipe</requirement>


### PR DESCRIPTION
The Galaxy administrator may use this variable to run the job with increased resources.