### PR TITLE
Fix for QuPath ROI Splitter (v0.3.1)

### DIFF
--- a/tools/qupath_roi_splitter/qupath_roi_splitter.py
+++ b/tools/qupath_roi_splitter/qupath_roi_splitter.py
@@ -22,15 +22,20 @@ def collect_roi_coords(input_roi, feature_index):
     else:
         coord_index = 0
         for sub_roi in input_roi["geometry"]["coordinates"]:
-            # Polygon with holes or MultiPolygon
-            if not isinstance(sub_roi[0][0], list):
-                all_coords.extend(collect_coords(sub_roi, feature_index, coord_index))
-                coord_index += len(sub_roi)
+            if len(sub_roi) == 2:
+                # Special case: LMD data
+                all_coords.extend(collect_coords([sub_roi], feature_index, coord_index))
+                coord_index += 1
             else:
-                # MultiPolygon with holes
-                for sub_coord in sub_roi:
-                    all_coords.extend(collect_coords(sub_coord, feature_index, coord_index))
-                    coord_index += len(sub_coord)
+                # Polygon with holes or MultiPolygon
+                if not isinstance(sub_roi[0][0], list):
+                    all_coords.extend(collect_coords(sub_roi, feature_index, coord_index))
+                    coord_index += len(sub_roi)
+                else:
+                    # MultiPolygon with holes
+                    for sub_coord in sub_roi:
+                        all_coords.extend(collect_coords(sub_coord, feature_index, coord_index))
+                        coord_index += len(sub_coord)
     return all_coords
 
 
@@ -103,7 +108,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Split ROI coordinates of QuPath TMA annotation by cell type (classification)")
     parser.add_argument("--qupath_roi", default=False, help="Input QuPath annotation (GeoJSON file)")
     parser.add_argument("--fill", action="store_true", required=False, help="Fill pixels in ROIs (order of coordinates will be lost)")
-    parser.add_argument('--version', action='version', version='%(prog)s 0.3.0')
+    parser.add_argument('--version', action='version', version='%(prog)s 0.3.1')
     parser.add_argument("--all", action="store_true", required=False, help="Extracts all ROIs")
     parser.add_argument("--img", action="store_true", required=False, help="Generates image of ROIs")
     args = parser.parse_args()

--- a/tools/qupath_roi_splitter/qupath_roi_splitter.xml
+++ b/tools/qupath_roi_splitter/qupath_roi_splitter.xml
@@ -43,7 +43,7 @@
         </collection>
     </outputs>
     <tests>
-        <test>
+        <test expect_num_outputs="2">
             <param name="input_collection">
                 <collection type="list">
                     <element name="annotations_TMA_E-5.geojson" value="annotations_TMA_E-5.geojson" />

--- a/tools/qupath_roi_splitter/qupath_roi_splitter.xml
+++ b/tools/qupath_roi_splitter/qupath_roi_splitter.xml
@@ -1,7 +1,7 @@
 <tool id="qupath_roi_splitter" name="QuPath ROI Splitter" version="@VERSION@+galaxy@VERSION_SUFFIX@">
     <description>Split ROI coordinates of QuPath TMA annotation by cell type (classification)</description>
     <macros>
-        <token name="@VERSION@">0.3.0</token>
+        <token name="@VERSION@">0.3.1</token>
         <token name="@VERSION_SUFFIX@">0</token>
     </macros>
     <requirements>
@@ -33,9 +33,10 @@
     </inputs>
     <outputs>
         <collection name="output_txts" type="list" label="${tool.name} on ${on_string}: ROI data">
-            <discover_datasets pattern="(?P&lt;name&gt;.*\.txt)" directory="out" visible="false" ext="txt"/>
+            <discover_datasets pattern="(?P&lt;name&gt;.*\.txt)" directory="out" visible="false" ext="tabular"/>
         </collection>
         <collection name="output_imgs" type="list" label="${tool.name} on ${on_string}: Images of ROIs">
+            <filter>img</filter>
             <discover_datasets pattern="(?P&lt;name&gt;.*\.png)" directory="out" visible="false" ext="png"/>
         </collection>
     </outputs>

--- a/tools/qupath_roi_splitter/qupath_roi_splitter.xml
+++ b/tools/qupath_roi_splitter/qupath_roi_splitter.xml
@@ -21,7 +21,9 @@
         #end for
         mkdir out
         && mv *.txt out/
+        #if $optional.img
         && mv *.png out/
+        #end if
     ]]></command>
     <inputs>
         <param name="input_collection" type="data_collection" format="geojson" label="Input QuPath annotation" help="Collection containing GeoJSON files"/>
@@ -36,7 +38,7 @@
             <discover_datasets pattern="(?P&lt;name&gt;.*\.txt)" directory="out" visible="false" ext="tabular"/>
         </collection>
         <collection name="output_imgs" type="list" label="${tool.name} on ${on_string}: Images of ROIs">
-            <filter>img</filter>
+            <filter>optional['img']</filter>
             <discover_datasets pattern="(?P&lt;name&gt;.*\.png)" directory="out" visible="false" ext="png"/>
         </collection>
     </outputs>


### PR DESCRIPTION
This version fixes the PNG output, changed the datatype of the coordinates to tabular and added a fix for a special case (LMD data).