### PR TITLE
Fix IonQuant Options in FragPipe

### DIFF
--- a/tools/fragpipe/fragpipe.xml
+++ b/tools/fragpipe/fragpipe.xml
@@ -154,6 +154,7 @@
         <param name="database_name" value="default/test.fasta" ftype="fasta"/>
         <param name="manifest" value="default/test.manifest" ftype="tabular"/>
         <param name="workflow_name" value="Default"/>
+        <param name="label_free_quantification_run" value="ionquant"/>
         <param name="output_options" value="workflow,log,combined_outputs,concatenated_outputs"/>
         <param name="license_agreements" value="true"/>
         <output name="concat_psm_tsv" ftype="tabular">

--- a/tools/fragpipe/macros.xml
+++ b/tools/fragpipe/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <import>msfragger_macros.xml</import>
     <token name="@TOOL_VERSION@">20.0</token>
-    <token name="@VERSION_SUFFIX@">2</token>
+    <token name="@VERSION_SUFFIX@">3</token>
     <xml name="requirements">
         <requirements>
             <requirement type="package" version="@TOOL_VERSION@">fragpipe</requirement>
@@ -719,7 +719,7 @@ $kv
                 <when value="no"/>
                 <when value="ionquant">
                     <section name="ionquant" expanded="false" title="IonQuant Label-Free Quantification">
-                        <param name="mbr" type="select" optional="true" label="Match between runs (MBR)" help="ionquant.mbr">
+                        <param name="mbr_select" type="select" optional="true" label="Match between runs (MBR)" help="ionquant.mbr">
                             <option value="0">No</option>
                             <option value="1">Yes</option>
                         </param>
@@ -821,11 +821,8 @@ $kv
             #set $wfdict['ionquant.run-ionquant'] = 'true'
             #set $wfdict['freequant.run-freequant'] = 'false'
             #set $cxt = $prfx.ionquant
-            #if $cxt.mbr != 'None'
-                #set $wfdict['ionquant.mbr'] = $cxt.mbr
-            #end if
-            #if $cxt.maxlfqbr is not None
-                #set $wfdict['ionquant.maxlfqbr'] = $cxt.maxlfqbr
+            #if $cxt.mbr_select != 'None'
+                #set $wfdict['ionquant.mbr'] = $cxt.mbr_select
             #end if
             #if $cxt.normalization != 'None'
                 #set $wfdict['ionquant.normalization'] = $cxt.normalization


### PR DESCRIPTION
Two options in IonQuant were incorrectly defined, causing the tool to fail immediately. I've fixed the automated test as well to cover this section.