### PR TITLE
Bump PeptideShaker wrappers for InstaNovo support

### DIFF
--- a/tools/peptideshaker/README.rst
+++ b/tools/peptideshaker/README.rst
@@ -9,7 +9,7 @@ GalaxyP - PeptideShaker
 Description
 -----------
 
-Perform protein identification combining numerous search engines (using SearchGUI) followed by peptide and protein inference with PeptideShaker.
+Perform protein identification combining numerous search engines and de novo sequencing algorithms (using SearchGUI) followed by peptide and protein inference with PeptideShaker.
 
 Includes tool wrappers for FastaCLI, IdentificationParametersCLI, SearchGUI and PeptideShaker.
 
@@ -19,7 +19,7 @@ FastaCLI adds decoy sequences to any fasta file.
 
 The Identification Parameters tool allows to create a parameters (par) file which can be (re)used later to parameterize SearchGUI or PeptideShaker.
 
-The SearchGUI tool takes any number of mgf files and performs searches on these. It creates a large zip archive with all search results, the original database and spectra.
+The SearchGUI tool takes any number of mgf files and performs searches or de novo sequencing on these. It creates a large zip archive with all search results, the original database when provided, and spectra.
 
 This can then be fed to the PeptideShaker tool which merges the results and performs peptide and protein inference.
 

--- a/tools/peptideshaker/macros_basic.xml
+++ b/tools/peptideshaker/macros_basic.xml
@@ -12,10 +12,10 @@
     </xml>
     <token name="@PROFILE@">24.2</token>
     <token name="@SEARCHGUI_MAJOR_VERSION@">4</token>
-    <token name="@SEARCHGUI_VERSION@">4.0.41</token>
-    <token name="@SEARCHGUI_VERSION_SUFFIX@">2</token>
-    <token name="@PEPTIDESHAKER_VERSION@">2.0.33</token>
-    <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">2</token>
+    <token name="@SEARCHGUI_VERSION@">4.3.17</token>
+    <token name="@SEARCHGUI_VERSION_SUFFIX@">0</token>
+    <token name="@PEPTIDESHAKER_VERSION@">3.0.13</token>
+    <token name="@PEPTIDESHAKER_VERSION_SUFFIX@">0</token>
     <xml name="citations">
         <citations>
             <citation type="doi">10.1186/1471-2105-12-70</citation>

--- a/tools/peptideshaker/peptide_shaker.xml
+++ b/tools/peptideshaker/peptide_shaker.xml
@@ -728,7 +728,7 @@
     <help>
 **What it does**
 
-PeptideShaker is a search engine for interpretation of proteomics identification results from multiple search engines, currently supporting X!Tandem, MS-GF+, MS Amanda, OMSSA, MyriMatch, Comet, Tide, Mascot, Andromeda and mzIdentML.
+PeptideShaker is a search engine for interpretation of proteomics identification results from multiple search engines and de novo sequencing algorithms, currently supporting X!Tandem, MS-GF+, MS Amanda, OMSSA, MyriMatch, Comet, Tide, Mascot, Andromeda, Novor, DirecTag, InstaNovo, InstaNovo+ and mzIdentML.
 
 http://compomics.github.io/projects/peptide-shaker.html
 

--- a/tools/peptideshaker/searchgui.xml
+++ b/tools/peptideshaker/searchgui.xml
@@ -11,6 +11,7 @@
     </macros>
     <requirements>
         <requirement type="package" version="@SEARCHGUI_VERSION@">searchgui</requirement>
+        <requirement type="package" version="1.2.2">instanovo</requirement>
         <requirement type="package" version="3.0">zip</requirement>
     </requirements>
     <expand macro="stdio" />
@@ -33,7 +34,9 @@
 
         ## echo the search engines to run (single quotes important because X!Tandem)
         echo '$search_engines_options.engines';
-        echo 'DB: ${input_fasta_file.element_identifier} sequences: ${input_fasta_file.metadata.sequences}';
+        #if $input_fasta_file:
+            echo 'DB: ${input_fasta_file.element_identifier} sequences: ${input_fasta_file.metadata.sequences}';
+        #end if
 
         ##Create a searchgui.properties file for the version, which will be added to the searchgui_results if not already present
         echo 'searchgui.version=@SEARCHGUI_VERSION@' >> searchgui.properties;
@@ -53,8 +56,10 @@
         ## copy the input .par file to the working folder
         cp '${input_parameters_file}' './SEARCHGUI_IdentificationParameters.par';
 
-        ## copy the input .fasta file to the working folder
-        cp '${input_fasta_file}' './input_fasta_file.fasta';
+        #if $input_fasta_file:
+            ## copy the input .fasta file to the working folder
+            cp '${input_fasta_file}' './input_fasta_file.fasta';
+        #end if
 
 
         ################
@@ -65,7 +70,9 @@
             --exec_dir="\$cwd/${bin_dir}"
             -use_log_folder 1
             -spectrum_files \$cwd
-            -fasta_file "\$cwd/input_fasta_file.fasta"
+            #if $input_fasta_file:
+                -fasta_file "\$cwd/input_fasta_file.fasta"
+            #end if
             -output_folder \$cwd/output
             -id_params ./SEARCHGUI_IdentificationParameters.par
             -temp_folder \$cwd/temp_folder
@@ -147,6 +154,24 @@
                 -directag 0
             #end if
 
+            #if 'InstaNovo' in $engines_list:
+                -instanovo 1
+            #else
+                -instanovo 0
+            #end if
+
+            #if 'InstaNovoPlus' in $engines_list:
+                -instanovo_plus 1
+            #else
+                -instanovo_plus 0
+            #end if
+
+            #if 'InstaNovoRefine' in $engines_list:
+                -instanovo_refine 1
+            #else
+                -instanovo_refine 0
+            #end if
+
             ## single zip file
             -output_option 0
 
@@ -169,7 +194,7 @@
     <inputs>
         <param format="json" name="input_parameters_file" type="data" label="Identification Parameters file"/>
 
-        <param format="fasta" name="input_fasta_file" type="data" label="Fasta file" help="For postprocessing with PeptideShaker the sequences must have UniProt style headers and contain decoy sequences (see help)."/>
+        <param format="fasta" name="input_fasta_file" type="data" optional="true" label="Fasta file" help="Required for database search engines. Optional for de novo-only runs. For postprocessing with PeptideShaker the sequences must have UniProt style headers and contain decoy sequences (see help)."/>
 
         <param name="peak_lists_files" format="mgf,mzml" type="data" multiple="true" label="Input Peak Lists"
             help="Select appropriate MGF/MZML dataset(s) from history.
@@ -177,9 +202,9 @@
 
         <!-- Search Engine Selection -->
         <section name="search_engines_options" expanded="true" title="Search Engine Options">
-            <param name="engines" type="select" display="checkboxes" multiple="True" label="DB-Search Engines">
+            <param name="engines" type="select" display="checkboxes" multiple="True" label="Search engines and de novo algorithms">
                 <help>Comet and Tide shouldn't both be selected since they use a similar algoritm. OMSSA might not work into isolated environments like containers. Ms Amanda may not work either when executed into isolated environments based on MacOS X (use SG 4.0.22 to solve any problem running MsAmanda).
-                    MetaMorpheus only produce results when using mzML format.</help>
+                    MetaMorpheus only produce results when using mzML format. InstaNovo with refinement first predicts with InstaNovo and then refines those predictions with InstaNovo+.</help>
                 <option value="X!Tandem" selected="True">X!Tandem</option>
                 <option value="MSGF" selected="True">MS-GF+</option>
                 <option value="OMSSA">OMSSA</option>
@@ -197,6 +222,9 @@
                 -->
                 <option value="DirecTag">DirecTag</option>
                 <option value="Novor">Novor (Select for non-commercial use only)</option>
+                <option value="InstaNovo">InstaNovo</option>
+                <option value="InstaNovoPlus">InstaNovo+</option>
+                <option value="InstaNovoRefine">InstaNovo with refinement</option>
                 <validator type="no_options" message="Please select at least one output file" />
             </param>
         </section>
@@ -353,9 +381,11 @@ Runs multiple search engines on any number of MGF peak lists using SearchGUI.
 
 Default:     X! Tandem and MS-GF+ are executed.
 
-Optional:     MyriMatch, MS-Amanda, MetaMorpheus, OMSSA (it may not work into isolated environments like containers), Comet, Tide, DirecTag and Novor can be executed.
+Optional:     MyriMatch, MS-Amanda, MetaMorpheus, OMSSA (it may not work into isolated environments like containers), Comet, Tide, DirecTag, Novor, InstaNovo, InstaNovo+ and InstaNovo with refinement can be executed.
 
 **Input FASTA**
+
+The FASTA input is required when running database search engines. It can be omitted for de novo-only runs such as InstaNovo, InstaNovo+ or InstaNovo with refinement.
 
 In order to allow for postprocessing with PeptideShaker the sequences must contain decoy sequences (see _here: https://github.com/compomics/searchgui/wiki/DatabaseHelp#decoy-sequences)
 and the FASTA header must either contain no "|" characters (then the whole header will be used as ID) or have the following format:


### PR DESCRIPTION
InstaNovo is a de novo peptide sequencing tool.

This PR adds Galaxy wrapper support for three InstaNovo workflows through SearchGUI:

- **InstaNovo**: de novo peptide sequencing with the transformer-based InstaNovo model.
- **InstaNovo+**: de novo peptide sequencing with the diffusion-based InstaNovo+ model.
- **InstaNovo with refinement**: InstaNovo predictions refined with InstaNovo+.

## Changes

- Bumps wrapper tokens to the SearchGUI and PeptideShaker versions expected to contain InstaNovo support.
- Adds `instanovo ==1.2.2` as a SearchGUI wrapper requirement.
- Adds SearchGUI wrapper options for:
  - `InstaNovo`
  - `InstaNovo+`
  - `InstaNovo with refinement`
- Maps those options to:
  - `-instanovo`
  - `-instanovo_plus`
  - `-instanovo_refine`
- Makes FASTA optional for de novo-only SearchGUI runs.
- Updates help text for de novo workflows.

## Relationship To PR #821

This PR should be rebased on or merged after galaxyproteomics/tools-galaxyp#821 if that PeptideShaker bump lands first.

PR #821 updates the wrappers for the newer SearchGUI/PeptideShaker line and refreshes test data. This PR layers InstaNovo-specific workflow options on top of that modernization.

Still needed before merge:

- Rebase on PR #821 if it merges first.
- Update test data after final SearchGUI/PeptideShaker release artifacts are available.
- Run `planemo lint` and targeted wrapper tests.

## Merge Order

Recommended order:

1. https://github.com/CompOmics/compomics-utilities/pull/73
2. https://github.com/CompOmics/searchgui/pull/387
3. https://github.com/CompOmics/peptide-shaker/pull/570
4. https://github.com/CompOmics/compomics-utilities/pull/74
5. https://github.com/CompOmics/denovogui/pull/53
6. https://github.com/bioconda/bioconda-recipes/pull/66604
7.  https://github.com/bioconda/bioconda-recipes/pull/66603
8. https://github.com/barsnes-group/peptide-shaker-online/pull/30
9. This PR