### PR TITLE
Detect msfragger OOM

### DIFF
--- a/tools/fragpipe/fragpipe.xml
+++ b/tools/fragpipe/fragpipe.xml
@@ -13,6 +13,7 @@
                level="fatal"
                description="A FragPipe pipeline process returned non-zero exit code."/>
         <regex source="both" match="java.lang.OutOfMemoryError" level="fatal_oom" description="Out of memory"/>
+        <regex source="both" match="Not enough memory allocated to" level="fatal_oom" description="Out of memory"/>
     </stdio>
     <version_command>
         fragpipe --msfragger_key @MSFRAGGER_ACADEMIC_USE_KEY@ --ionquant_key @IONQUANT_ACADEMIC_USE_KEY@ --help | grep 'FragPipe v'

--- a/tools/fragpipe/macros.xml
+++ b/tools/fragpipe/macros.xml
@@ -1,7 +1,7 @@
 <macros>
     <import>msfragger_macros.xml</import>
     <token name="@TOOL_VERSION@">23.0</token>
-    <token name="@VERSION_SUFFIX@">4</token>
+    <token name="@VERSION_SUFFIX@">5</token>
     <token name="@TOOL_PROFILE@">25.1</token>
 
     <!--


### PR DESCRIPTION
Ideally fragpipe would not return an exit code of 0 in this case .. otherwise Galaxy would be able to detect the OOM without this change (but only for some runners I guess). 

@reid-wagner  you may decide if this should go in the next release 